### PR TITLE
Import the AMOTA necessary files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,5 +11,6 @@ if(CONFIG_AMBIQ_HAL)
         utils
         )
     add_subdirectory(mcu)
+    add_subdirectory(utils)
     add_subdirectory(components)
 endif()

--- a/mcu/apollo4p/CMakeLists.txt
+++ b/mcu/apollo4p/CMakeLists.txt
@@ -20,6 +20,7 @@ zephyr_library_sources(hal/mcu/am_hal_mram.c)
 zephyr_library_sources(hal/mcu/am_hal_rtc.c)
 zephyr_library_sources(hal/mcu/am_hal_utils.c)
 zephyr_library_sources(hal/mcu/am_hal_mcuctrl.c)
+zephyr_library_sources(hal/mcu/am_hal_reset.c)
 
 if(CONFIG_AMBIQ_HAL_USE_GPIO)
     zephyr_library_sources(hal/am_hal_gpio.c)
@@ -46,6 +47,10 @@ endif()
 if(CONFIG_AMBIQ_HAL_USE_MSPI)
     zephyr_library_sources(hal/mcu/am_hal_mspi.c)
     zephyr_library_sources(hal/mcu/am_hal_cmdq.c)
+endif()
+
+if(CONFIG_BT_AMOTA)
+    zephyr_library_sources(hal/mcu/am_hal_secure_ota.c)
 endif()
 
 zephyr_include_directories(hal)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (c) 2023 Ambiq Micro Inc. 
+
+zephyr_library()
+
+if(CONFIG_BT_AMOTA)
+    zephyr_library_sources(am_util_bootloader.c)
+    zephyr_library_sources(am_util_multi_boot.c)
+endif()

--- a/utils/am_util_bootloader.c
+++ b/utils/am_util_bootloader.c
@@ -1,0 +1,1066 @@
+//*****************************************************************************
+//
+//! @file am_util_bootloader.c
+//!
+//! @brief
+//
+//*****************************************************************************
+
+//*****************************************************************************
+//
+// ${copyright}
+//
+// This is part of revision ${version} of the AmbiqSuite Development Package.
+//
+//*****************************************************************************
+#include <stdint.h>
+#include <stdbool.h>
+#include "am_mcu_apollo.h"
+#include "am_util_bootloader.h"
+
+#ifdef BOOTLOADER_DEBUG
+#include "am_util_stdio.h"
+#include "am_util_delay.h"
+// might need va_list someday, but not so far today.
+#define DPRINTF(x) am_util_stdio_printf x
+#else
+#define DPRINTF(x)
+#endif
+
+#if defined(AM_PART_APOLLO3) || defined(AM_PART_APOLLO3P)
+const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_INPUT_ENABLE =
+{
+  .uFuncSel             = AM_HAL_PIN_0_GPIO,
+  .eGPInput             = AM_HAL_GPIO_PIN_INPUT_ENABLE,
+};
+
+const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_INPUT_DISABLE =
+{
+  .uFuncSel             = AM_HAL_PIN_0_GPIO,
+  .eGPInput             = AM_HAL_GPIO_PIN_INPUT_NONE,
+};
+#endif
+
+//*****************************************************************************
+//
+// Forward declarations.
+//
+//*****************************************************************************
+#if defined(__GNUC__)  || defined(keil6)
+void __attribute__((naked)) am_util_bootloader_encrypted_image_run(am_util_bootloader_image_t *psImage);
+void __attribute__((naked)) am_util_bootloader_clear_image_run(am_util_bootloader_image_t *psImage);
+#endif
+
+#ifdef  keil
+__asm void am_util_bootloader_encrypted_image_run(am_util_bootloader_image_t *psImage);
+__asm void am_util_bootloader_clear_image_run(am_util_bootloader_image_t *psImage);
+#endif
+
+#ifdef iar
+void am_util_bootloader_encrypted_image_run(am_util_bootloader_image_t *psImage);
+void am_util_bootloader_clear_image_run(am_util_bootloader_image_t *psImage);
+#endif
+
+//*****************************************************************************
+//
+// CRC-32 table
+// Polynomial = 0x1EDC6F41 (also listed as CRC-32C or CRC-32/4)
+//
+// This polynomial should catch all errors up to 4 bits for image sizes under
+// about 255MB (which easily covers anything we can actually fit in flash), and
+// it has a reasonably high probablility of catching bigger errors.
+//
+// See http://users.ece.cmu.edu/~koopman/crc for more information.
+//
+//*****************************************************************************
+#define CRC32_POLYNOMIAL                    0x1EDC6F41
+const static uint32_t g_pui32CRC32Table[256] =
+{
+    0x00000000, 0x1EDC6F41, 0x3DB8DE82, 0x2364B1C3,
+    0x7B71BD04, 0x65ADD245, 0x46C96386, 0x58150CC7,
+    0xF6E37A08, 0xE83F1549, 0xCB5BA48A, 0xD587CBCB,
+    0x8D92C70C, 0x934EA84D, 0xB02A198E, 0xAEF676CF,
+    0xF31A9B51, 0xEDC6F410, 0xCEA245D3, 0xD07E2A92,
+    0x886B2655, 0x96B74914, 0xB5D3F8D7, 0xAB0F9796,
+    0x05F9E159, 0x1B258E18, 0x38413FDB, 0x269D509A,
+    0x7E885C5D, 0x6054331C, 0x433082DF, 0x5DECED9E,
+    0xF8E959E3, 0xE63536A2, 0xC5518761, 0xDB8DE820,
+    0x8398E4E7, 0x9D448BA6, 0xBE203A65, 0xA0FC5524,
+    0x0E0A23EB, 0x10D64CAA, 0x33B2FD69, 0x2D6E9228,
+    0x757B9EEF, 0x6BA7F1AE, 0x48C3406D, 0x561F2F2C,
+    0x0BF3C2B2, 0x152FADF3, 0x364B1C30, 0x28977371,
+    0x70827FB6, 0x6E5E10F7, 0x4D3AA134, 0x53E6CE75,
+    0xFD10B8BA, 0xE3CCD7FB, 0xC0A86638, 0xDE740979,
+    0x866105BE, 0x98BD6AFF, 0xBBD9DB3C, 0xA505B47D,
+    0xEF0EDC87, 0xF1D2B3C6, 0xD2B60205, 0xCC6A6D44,
+    0x947F6183, 0x8AA30EC2, 0xA9C7BF01, 0xB71BD040,
+    0x19EDA68F, 0x0731C9CE, 0x2455780D, 0x3A89174C,
+    0x629C1B8B, 0x7C4074CA, 0x5F24C509, 0x41F8AA48,
+    0x1C1447D6, 0x02C82897, 0x21AC9954, 0x3F70F615,
+    0x6765FAD2, 0x79B99593, 0x5ADD2450, 0x44014B11,
+    0xEAF73DDE, 0xF42B529F, 0xD74FE35C, 0xC9938C1D,
+    0x918680DA, 0x8F5AEF9B, 0xAC3E5E58, 0xB2E23119,
+    0x17E78564, 0x093BEA25, 0x2A5F5BE6, 0x348334A7,
+    0x6C963860, 0x724A5721, 0x512EE6E2, 0x4FF289A3,
+    0xE104FF6C, 0xFFD8902D, 0xDCBC21EE, 0xC2604EAF,
+    0x9A754268, 0x84A92D29, 0xA7CD9CEA, 0xB911F3AB,
+    0xE4FD1E35, 0xFA217174, 0xD945C0B7, 0xC799AFF6,
+    0x9F8CA331, 0x8150CC70, 0xA2347DB3, 0xBCE812F2,
+    0x121E643D, 0x0CC20B7C, 0x2FA6BABF, 0x317AD5FE,
+    0x696FD939, 0x77B3B678, 0x54D707BB, 0x4A0B68FA,
+    0xC0C1D64F, 0xDE1DB90E, 0xFD7908CD, 0xE3A5678C,
+    0xBBB06B4B, 0xA56C040A, 0x8608B5C9, 0x98D4DA88,
+    0x3622AC47, 0x28FEC306, 0x0B9A72C5, 0x15461D84,
+    0x4D531143, 0x538F7E02, 0x70EBCFC1, 0x6E37A080,
+    0x33DB4D1E, 0x2D07225F, 0x0E63939C, 0x10BFFCDD,
+    0x48AAF01A, 0x56769F5B, 0x75122E98, 0x6BCE41D9,
+    0xC5383716, 0xDBE45857, 0xF880E994, 0xE65C86D5,
+    0xBE498A12, 0xA095E553, 0x83F15490, 0x9D2D3BD1,
+    0x38288FAC, 0x26F4E0ED, 0x0590512E, 0x1B4C3E6F,
+    0x435932A8, 0x5D855DE9, 0x7EE1EC2A, 0x603D836B,
+    0xCECBF5A4, 0xD0179AE5, 0xF3732B26, 0xEDAF4467,
+    0xB5BA48A0, 0xAB6627E1, 0x88029622, 0x96DEF963,
+    0xCB3214FD, 0xD5EE7BBC, 0xF68ACA7F, 0xE856A53E,
+    0xB043A9F9, 0xAE9FC6B8, 0x8DFB777B, 0x9327183A,
+    0x3DD16EF5, 0x230D01B4, 0x0069B077, 0x1EB5DF36,
+    0x46A0D3F1, 0x587CBCB0, 0x7B180D73, 0x65C46232,
+    0x2FCF0AC8, 0x31136589, 0x1277D44A, 0x0CABBB0B,
+    0x54BEB7CC, 0x4A62D88D, 0x6906694E, 0x77DA060F,
+    0xD92C70C0, 0xC7F01F81, 0xE494AE42, 0xFA48C103,
+    0xA25DCDC4, 0xBC81A285, 0x9FE51346, 0x81397C07,
+    0xDCD59199, 0xC209FED8, 0xE16D4F1B, 0xFFB1205A,
+    0xA7A42C9D, 0xB97843DC, 0x9A1CF21F, 0x84C09D5E,
+    0x2A36EB91, 0x34EA84D0, 0x178E3513, 0x09525A52,
+    0x51475695, 0x4F9B39D4, 0x6CFF8817, 0x7223E756,
+    0xD726532B, 0xC9FA3C6A, 0xEA9E8DA9, 0xF442E2E8,
+    0xAC57EE2F, 0xB28B816E, 0x91EF30AD, 0x8F335FEC,
+    0x21C52923, 0x3F194662, 0x1C7DF7A1, 0x02A198E0,
+    0x5AB49427, 0x4468FB66, 0x670C4AA5, 0x79D025E4,
+    0x243CC87A, 0x3AE0A73B, 0x198416F8, 0x075879B9,
+    0x5F4D757E, 0x41911A3F, 0x62F5ABFC, 0x7C29C4BD,
+    0xD2DFB272, 0xCC03DD33, 0xEF676CF0, 0xF1BB03B1,
+    0xA9AE0F76, 0xB7726037, 0x9416D1F4, 0x8ACABEB5
+};
+
+//*****************************************************************************
+//
+//! @brief CRC-32 implementation for the boot loader.
+//!
+//! @param pvData - Pointer to the data to be checked.
+//! @param ui32NumBytes - Number of bytes to check.
+//!
+//! This function performs a CRC-32 on the input data and returns the 32-bit
+//! result. This version does not use a table, so it has a smaller code
+//! footprint.
+//!
+//! @return 32-bit CRC value.
+//
+//*****************************************************************************
+uint32_t
+am_util_bootloader_crc32(const void *pvData, uint32_t ui32NumBytes)
+{
+    uint32_t ui32CRC, i, j;
+    uint8_t *pui8Data;
+
+    ui32CRC = 0;
+    pui8Data = (uint8_t *) pvData;
+
+    for ( i = 0; i < ui32NumBytes; i++ )
+    {
+        ui32CRC ^= pui8Data[i] << 24;
+
+        for ( j = 0; j < 8; j++ )
+        {
+            ui32CRC = (ui32CRC & 0x80000000 ?
+                       ((ui32CRC << 1) ^ CRC32_POLYNOMIAL):
+                       (ui32CRC << 1));
+        }
+    }
+
+    return ui32CRC;
+}
+
+//*****************************************************************************
+//
+//! @brief Faster CRC-32 implementation for the boot loader.
+//!
+//! @param pvData - Pointer to the data to be checked.
+//! @param ui32NumBytes - Number of bytes to check.
+//!
+//! This function performs a CRC-32 on the input data and returns the 32-bit
+//! result. This version uses a 256-entry lookup table to speed up the
+//! computation of the result.
+//!
+//! @return 32-bit CRC value.
+//
+//*****************************************************************************
+uint32_t
+am_util_bootloader_fast_crc32(const void *pvData, uint32_t ui32NumBytes)
+{
+    uint32_t ui32CRC, ui32CRCIndex, i;
+    uint8_t *pui8Data;
+
+    ui32CRC = 0;
+    pui8Data = (uint8_t *) pvData;
+
+    for (i = 0; i < ui32NumBytes; i++ )
+    {
+        ui32CRCIndex = pui8Data[i] ^ (ui32CRC >> 24);
+        ui32CRC = (ui32CRC << 8) ^ g_pui32CRC32Table[ui32CRCIndex];
+    }
+
+    return ui32CRC;
+}
+
+//*****************************************************************************
+//
+//! @brief CRC-32 implementation allowing multiple partial images.
+//!
+//! @param pvData - Pointer to the data to be checked.
+//! @param ui32NumBytes - Number of bytes to check.
+//! @param pui32CRC - Location to store the partial CRC32 result.
+//!
+//! This function performs a CRC-32 on the input data and returns the 32-bit
+//! result. This version uses a 256-entry lookup table to speed up the
+//! computation of the result. The result of the CRC32 is stored in the
+//! location given by the caller. This allows the caller to keep a "running"
+//! CRC for individual chunks of an image.
+//!
+//! @return 32-bit CRC value.
+//
+//*****************************************************************************
+void
+am_util_bootloader_partial_crc32(const void *pvData, uint32_t ui32NumBytes,
+                            uint32_t *pui32CRC)
+{
+    uint32_t ui32CRCIndex, i;
+    uint8_t *pui8Data;
+
+    uint32_t ui32TempCRC = *pui32CRC;
+
+    pui8Data = (uint8_t *) pvData;
+
+    for ( i = 0; i < ui32NumBytes; i++ )
+    {
+        ui32CRCIndex = pui8Data[i] ^ (ui32TempCRC >> 24);
+        ui32TempCRC = (ui32TempCRC << 8) ^ g_pui32CRC32Table[ui32CRCIndex];
+    }
+
+    *pui32CRC = ui32TempCRC;
+}
+
+//*****************************************************************************
+//
+//! @brief Check the flash contents of a boot image to make sure it's safe to run.
+//!
+//! @param psImage - Pointer to the image structure.
+//!
+//! This function is used to determine whether the flash contents of a boot image
+//! is safe to run.
+//!
+//! @return true if the image is safe to run.
+//
+//*****************************************************************************
+bool
+am_util_bootloader_flash_check(am_util_bootloader_image_t *psImage)
+{
+    am_hal_mcuctrl_device_t sDevice;
+    uint32_t ui32ResetVector, ui32StackPointer, ui32LinkAddress;
+
+    ui32LinkAddress = (uint32_t) psImage->pui32LinkAddress;
+    DPRINTF(("Entering %s 0x%08x\r\n", __func__, (uintptr_t)psImage));
+
+    // Get chip specific info
+#if defined(AM_PART_APOLLO3_API) || defined(AM_PART_APOLLO4_API) || defined(AM_PART_APOLLO5_API)
+    am_hal_mcuctrl_info_get(AM_HAL_MCUCTRL_INFO_DEVICEID, &sDevice);
+#else
+    am_hal_mcuctrl_device_info_get(&sDevice);
+#endif
+
+    //
+    // Make sure the link address is in flash.
+    //
+#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+    if (((AM_HAL_MRAM_ADDR != 0) && (ui32LinkAddress < AM_HAL_MRAM_ADDR)) ||
+        (ui32LinkAddress >= (AM_HAL_MRAM_ADDR + sDevice.ui32FlashSize)))
+#else
+    if (((AM_HAL_FLASH_ADDR != 0) && (ui32LinkAddress < AM_HAL_FLASH_ADDR)) ||
+        (ui32LinkAddress >= (AM_HAL_FLASH_ADDR + sDevice.ui32FlashSize)))
+#endif
+    {
+        DPRINTF(("Link address outside of flash. 0x%08x\r\n", ui32LinkAddress));
+        return false;
+    }
+
+    //
+    // Check to see if the image was encrypted. If it was, these tests won't
+    // work. We'll need to just skip them.
+    //
+    if ( psImage->bEncrypted == false )
+    {
+        ui32StackPointer = psImage->pui32LinkAddress[0];
+        ui32ResetVector = psImage->pui32LinkAddress[1];
+    }
+    else
+    {
+        ui32StackPointer = (uint32_t) psImage->pui32StackPointer;
+        ui32ResetVector = (uint32_t) psImage->pui32ResetVector;
+    }
+
+#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+    //
+    // Make sure the stack is in SRAM.
+    //
+    if (((SRAM_BASEADDR != 0) && (ui32StackPointer < SRAM_BASEADDR))
+        || (ui32StackPointer >= (SRAM_BASEADDR + sDevice.ui32DTCMSize)))
+    {
+        DPRINTF(("Stack not in SRAM 0x%08x\r\n", ui32StackPointer));
+        return false;
+    }
+#else
+    //
+    // Make sure the stack is in SRAM.
+    //
+    if (((SRAM_BASEADDR != 0) && (ui32StackPointer < SRAM_BASEADDR))
+        || (ui32StackPointer >= (SRAM_BASEADDR + sDevice.ui32SRAMSize)))
+    {
+        DPRINTF(("Stack not in SRAM 0x%08x\r\n", ui32StackPointer));
+        return false;
+    }
+#endif
+    
+    //
+    // Make sure the reset vector points somewhere in the image.
+    //
+    if (ui32ResetVector < ui32LinkAddress ||
+        ui32ResetVector >= (ui32LinkAddress + psImage->ui32NumBytes))
+    {
+        DPRINTF(("Reset Vector not in image 0x%08x\r\n", ui32ResetVector));
+        return false;
+    }
+
+    //
+    // If the image isn't encrypted, run a CRC32.
+    //
+    if ( psImage->bEncrypted == false )
+    {
+        //
+        // Run a CRC on the image to make sure it matches the stored checksum
+        // value.
+        //
+        if ( am_util_bootloader_fast_crc32(psImage->pui32LinkAddress, psImage->ui32NumBytes) !=
+             psImage->ui32CRC )
+        {
+            DPRINTF(("Bad CRC 0x%08x\r\n", psImage->ui32CRC));
+            return false;
+        }
+    }
+
+    //
+    // If those tests pass, we're probably safe to run.
+    //
+    return true;
+}
+
+//*****************************************************************************
+//
+//! @brief Checks the override GPIO for manual override
+//!
+//! @param psImage - Pointer to the image structure.
+//!
+//! The image structure specifies a GPIO to manually override this test.
+//! If the GPIO state matches the state specified in the structure, this function
+//! returns false
+//!
+//! @return true if override is asserted
+//
+//*****************************************************************************
+bool
+am_hal_bootloader_override_check(am_util_bootloader_image_t *psImage)
+{
+    DPRINTF(("Entering %s 0x%08x\r\n", __func__, (uintptr_t)psImage));
+    uint32_t    ui32OverridePin;
+    //
+    // Check the override GPIO
+    //
+    if ( psImage->ui32OverrideGPIO != 0xFFFFFFFF )
+    {
+#ifdef BOOTLOADER_DEBUG
+        if ( psImage->ui32OverridePolarity & 0x2 )
+        {
+            am_hal_gpio_pin_config(17, AM_HAL_PIN_OUTPUT);
+            am_hal_gpio_out_bit_set(17);
+            am_util_delay_us(100);
+            am_hal_gpio_out_bit_clear(17);
+        }
+#endif
+        //
+        // Temporarily configure the override pin as an input.
+        //
+#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+        am_hal_gpio_pinconfig(psImage->ui32OverrideGPIO, am_hal_gpio_pincfg_input);
+#else
+#if defined(AM_PART_APOLLO3) || defined(AM_PART_APOLLO3P)
+        am_hal_gpio_pinconfig(psImage->ui32OverrideGPIO, g_AM_HAL_GPIO_INPUT_ENABLE);
+#else
+        am_hal_gpio_pin_config(psImage->ui32OverrideGPIO, AM_HAL_PIN_INPUT);
+#endif
+#endif
+        //
+        // If the override pin matches the specified polarity, force a failure.
+        //
+#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+        am_hal_gpio_state_read(psImage->ui32OverrideGPIO, AM_HAL_GPIO_INPUT_READ, &ui32OverridePin );
+#else
+#if defined(AM_PART_APOLLO3) || defined(AM_PART_APOLLO3P)
+        am_hal_gpio_state_read(psImage->ui32OverrideGPIO, AM_HAL_GPIO_INPUT_READ, &ui32OverridePin );
+#else
+        ui32OverridePin = am_hal_gpio_input_bit_read(psImage->ui32OverrideGPIO);
+#endif
+#endif
+        if ( ui32OverridePin == (psImage->ui32OverridePolarity & 0x1) )
+        {
+            DPRINTF(("Override Pin %d matches Polarity, force failure. %d, %d\r\n", psImage->ui32OverrideGPIO,  ui32OverridePin, psImage->ui32OverridePolarity));
+            //
+            // Make sure to disable the pin before continuing.
+            //
+#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+            am_hal_gpio_pinconfig(psImage->ui32OverrideGPIO, am_hal_gpio_pincfg_disabled);
+#else
+#if defined(AM_PART_APOLLO3) || defined(AM_PART_APOLLO3P)
+            am_hal_gpio_pinconfig(psImage->ui32OverrideGPIO, g_AM_HAL_GPIO_INPUT_DISABLE);
+#else
+            am_hal_gpio_pin_config(psImage->ui32OverrideGPIO, AM_HAL_PIN_DISABLE);
+#endif
+#endif
+            return true;
+        }
+#ifdef BOOTLOADER_DEBUG
+        else
+        {
+            DPRINTF(("Override Pin %d mismatches Polarity, load image. %d, %d\r\n", psImage->ui32OverrideGPIO,  ui32OverridePin, psImage->ui32OverridePolarity));
+        }
+#endif
+
+        //
+        // If the test passed, we still need to make sure the GPIO is disabled,
+        // as it might interfere with the program we are (presumably) about to
+        // boot.
+        //
+#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+            am_hal_gpio_pinconfig(psImage->ui32OverrideGPIO, am_hal_gpio_pincfg_disabled);
+#else
+#if defined(AM_PART_APOLLO3) || defined(AM_PART_APOLLO3P)
+            am_hal_gpio_pinconfig(psImage->ui32OverrideGPIO, g_AM_HAL_GPIO_INPUT_DISABLE);
+#else
+            am_hal_gpio_pin_config(psImage->ui32OverrideGPIO, AM_HAL_PIN_DISABLE);
+#endif
+#endif
+    }
+
+    return false;
+}
+
+//*****************************************************************************
+//
+//! @brief Checks a boot image to make sure it's safe to run.
+//!
+//! @param psImage - Pointer to the image structure.
+//!
+//! This function is used to determine whether a boot image is safe to run. It
+//! verifies that the starting stack-pointer and reset vector entries for the
+//! new image are reasonable. If these tests pass, it also runs a CRC-32 on the
+//! image and checks the result against the expected CRC-32 value from the
+//! image structure.
+//!
+//! The image structure can also specify a GPIO to manually override this test.
+//! If the GPIO state matches the state specified in the structure, this test
+//! will mark the image as "unsafe" regardless of the other conditions.
+//!
+//! @return true if the image is safe to run.
+//
+//*****************************************************************************
+bool
+am_util_bootloader_image_check(am_util_bootloader_image_t *psImage)
+{
+    if (am_hal_bootloader_override_check(psImage) == true)
+    {
+        return am_util_bootloader_flash_check(psImage);
+    }
+    else
+    {
+        return false;
+    }
+
+}
+
+//*****************************************************************************
+//
+//! @brief Validates a information structure integrity.
+//!
+//! @param pInfo is a pointer to the information structure
+//! @param size is the size of the structure
+//!
+//! This function will compute the CRC for the information structure and
+//! validate it against the contents in the last 4 bytes of the same.
+//! It assumes that the structure contains the CRC-32 of the information in the
+//! last 4 bytes of the structure
+//!
+//! @return true if the check passes.
+//
+//*****************************************************************************
+bool
+am_util_bootloader_validate_structure(uint32_t *pInfo, uint32_t size)
+{
+    uint32_t ui32Crc = 0;
+    // CRC value is the last 4 bytes of the structure
+    uint32_t *pCrc = pInfo + size / 4 - 1;
+    // Compute and validate CRC of the structure
+    am_util_bootloader_partial_crc32(pInfo, size - 4, &ui32Crc);
+    if (*pCrc != ui32Crc)
+    {
+        return false;
+    }
+    else
+    {
+        return true;
+    }
+}
+
+//*****************************************************************************
+//
+//! @brief Updates the bootloader flag page with a new image pointer.
+//!
+//! @param psImage is a pointer to the image structure to use.
+//! @param pui8FlagPage is a pointer to the flag page address.
+//!
+//! This function also computes and updates the checksum of the image info.
+//! This function will overwrite the existing flag page entry with a new
+//! reference to the image described by psImage.
+//!
+//! @return None.
+//
+//*****************************************************************************
+int
+am_util_bootloader_flag_page_update(am_util_bootloader_image_t *psImage,
+                               uint32_t *pui32FlagPage)
+{
+    uint32_t ui32Critical;
+    psImage->ui32Checksum = 0;
+    DPRINTF(("Image to use: 0x%08x\r\n", (uintptr_t)psImage));
+    DPRINTF(("Flag page address: 0x%08x\r\n", (uintptr_t)pui32FlagPage));
+
+    // Compute CRC of the structure
+    am_util_bootloader_partial_crc32(psImage, sizeof(*psImage) - 4, &psImage->ui32Checksum);
+    //
+    // Start a critical section.
+    //
+    ui32Critical = am_hal_interrupt_master_disable();
+#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+    int rc = am_hal_mram_main_program(AM_HAL_MRAM_PROGRAM_KEY,
+                              (uint32_t *) psImage,
+                              pui32FlagPage,
+                              sizeof(am_util_bootloader_image_t) / 4);
+#else
+    uint32_t ui32Block, ui32Page;
+
+    //
+    // Calculate the correct flag page number.
+    //
+    ui32Page = AM_HAL_FLASH_ADDR2PAGE((uintptr_t)pui32FlagPage);
+    DPRINTF(("Flag page %d\r\n", ui32Page));
+    ui32Block = AM_HAL_FLASH_ADDR2INST((uint32_t)pui32FlagPage);
+    DPRINTF(("Flag page in block %d\r\n", ui32Block));
+
+    //
+    // Erase the page.
+    //
+    int rc = am_hal_flash_page_erase(AM_HAL_FLASH_PROGRAM_KEY, ui32Block, ui32Page);
+    DPRINTF(("Flash Erased %d\r\n", rc));
+    //
+    // Write the psImage structure directly to the flag page.
+    //
+    rc = am_hal_flash_program_main(AM_HAL_FLASH_PROGRAM_KEY,
+                              (uint32_t *) psImage,
+                              pui32FlagPage,
+                              sizeof(am_util_bootloader_image_t) / 4);
+#endif
+    //
+    // Exit the critical section.
+    //
+    am_hal_interrupt_master_set(ui32Critical);
+    DPRINTF(("Done. %d\r\n", rc));
+    return rc;
+}
+
+
+//*****************************************************************************
+//
+//! @brief Check an index against a 32b mask value - used to implement a
+//! monotonic counter.
+//!
+//! @param index is the index to be validated
+//! @param pMask is the pointer to the mask.
+//!
+//! This function can be used to validate an index against valid values
+//! The mask indicates the valid index values - up to 32 of them.
+//! MSB corresponds to index 0, bit 30 corresponds to index 1 and so on,
+//! LSB corresponds to index 31
+//!
+//! @return return false if the bit corresponding to index is set.
+//
+//*****************************************************************************
+bool
+am_util_bootloader_check_index(uint32_t index, uint32_t *pMask)
+{
+    uint32_t valid = *pMask;
+    if (index > 31)
+    {
+        return true;
+    }
+    if (valid & (1 << (31 - index)))
+    {
+        return false;
+    }
+    return true;
+
+}
+
+//*****************************************************************************
+//
+//! @brief Erase a flash page
+//!
+//! @param ui32Addr is the starting address of flash page to be erased
+//!
+//! This function will erase the designated flash page
+//! Any existing data on the page will be erased even if number of
+//! bytes is less than page size
+//!
+//! @return none
+//
+//*****************************************************************************
+void
+am_util_bootloader_erase_flash_page(uint32_t ui32Addr)
+{
+#if !defined(AM_PART_APOLLO4) && !defined(AM_PART_APOLLO4B) && !defined(AM_PART_APOLLO4L) && !defined(AM_PART_APOLLO4P)
+    uint32_t ui32Critical;
+    uint32_t ui32CurrentPage, ui32CurrentBlock;
+    //
+    // Figure out what page and block we're working on.
+    //
+    ui32CurrentPage =  AM_HAL_FLASH_ADDR2PAGE(ui32Addr);
+    ui32CurrentBlock = AM_HAL_FLASH_ADDR2INST(ui32Addr);
+    //
+    // Start a critical section.
+    //
+    ui32Critical = am_hal_interrupt_master_disable();
+    am_hal_flash_page_erase(AM_HAL_FLASH_PROGRAM_KEY,
+                                ui32CurrentBlock, ui32CurrentPage);
+    //
+    // Exit the critical section.
+    //
+    am_hal_interrupt_master_set(ui32Critical);
+#endif
+}
+
+//*****************************************************************************
+//
+//! @brief Write to flash area within a flash page
+//!
+//! @param ui32WriteAddr is the starting address of flash to be programmed
+//! @param pui32ReadAddr is the pointer to data to be programmed
+//! @param numBytes is the number of bytes to be programmed
+//!
+//! This function will write to the designated flash area. This function does
+//! not erase the page, and hence if it has not been erased earlier, it will
+//! effectively AND the new data to existing flash content.
+//!
+//! All the write should be within a flash page.  It does not affect
+//! rest of the flash page.
+//!
+//! @return none
+//
+//*****************************************************************************
+void
+am_util_bootloader_write_flash_within_page(uint32_t ui32WriteAddr,
+                                      uint32_t *pui32ReadAddr,
+                                      uint32_t ui32NumWords)
+{
+    uint32_t ui32Critical;
+
+    //
+    // Start a critical section.
+    //
+    ui32Critical = am_hal_interrupt_master_disable();
+    //
+    // Program the flash page with the data we just received.
+    //
+#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) ||  defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+    am_hal_mram_main_program(AM_HAL_MRAM_PROGRAM_KEY, pui32ReadAddr,
+                              (uint32_t *)ui32WriteAddr, ui32NumWords);
+#else
+    am_hal_flash_program_main(AM_HAL_FLASH_PROGRAM_KEY, pui32ReadAddr,
+                              (uint32_t *)ui32WriteAddr, ui32NumWords);
+#endif
+    //
+    // Exit the critical section.
+    //
+    am_hal_interrupt_master_set(ui32Critical);
+}
+
+//*****************************************************************************
+//
+//! @brief Reprogram a flash page
+//!
+//! @param ui32WriteAddr is the starting address of flash page to be programmed
+//! @param pui32ReadAddr is the pointer to data to be programmed
+//! @param numBytes is the number of bytes to be programmed
+//!
+//! This function will re-program the designated flash page by erasing & then
+//! writing new data. Any existing data will be overwritten even if number of
+//! bytes is less than page size
+//!
+//! @return none
+//
+//*****************************************************************************
+void
+am_util_bootloader_program_flash_page(uint32_t ui32WriteAddr,
+                                 uint32_t *pui32ReadAddr, uint32_t numBytes)
+{
+    uint32_t ui32Critical;
+    uint32_t ui32WordsInBuffer;
+
+    am_util_bootloader_erase_flash_page(ui32WriteAddr);
+
+    ui32WordsInBuffer = (numBytes + 3) / 4;
+    //
+    // Start a critical section.
+    //
+    ui32Critical = am_hal_interrupt_master_disable();
+    //
+    // Program the flash page with the data we just received.
+    //
+#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+    am_hal_mram_main_program(AM_HAL_MRAM_PROGRAM_KEY, pui32ReadAddr,
+                              (uint32_t *)ui32WriteAddr, ui32WordsInBuffer);
+#else
+    am_hal_flash_program_main(AM_HAL_FLASH_PROGRAM_KEY, pui32ReadAddr,
+                              (uint32_t *)ui32WriteAddr, ui32WordsInBuffer);
+#endif
+    //
+    // Exit the critical section.
+    //
+    am_hal_interrupt_master_set(ui32Critical);
+}
+
+
+//*****************************************************************************
+//
+//! @brief Execute an image that has already been written to flash.
+//!
+//! @param psImage is a pointer to the image structure.
+//!
+//! This function can be used to "run" a program that has already been
+//! downloaded and written to flash. It does this by reading the initial
+//! stack-pointer and reset vector information from the image written in flash,
+//! writing that information to the relevant registers, and immediately
+//! branching to the new reset vector location.
+//!
+//! Note that this method does not include any type of reset. It is the callers
+//! responsibility to ensure that the MCU is in a valid state for the
+//! subsequent program to run. One way to guarantee this is to run this
+//! function very early after a RESET event, before clocks or peripherals are
+//! configured.
+//!
+//! @return The function does not return.
+//
+//*****************************************************************************
+void
+am_util_bootloader_image_run(am_util_bootloader_image_t *psImage)
+{
+    //
+    // The underlying boot sequence is a little different depeding on whether
+    // the image was delivered as an encrypted image or as a cleartext image.
+    // We will call the correct assembly routine based on what the image
+    // structure tells us.
+    //
+    if ( psImage->bEncrypted )
+    {
+        am_util_bootloader_encrypted_image_run(psImage);
+    }
+    else
+    {
+        am_util_bootloader_clear_image_run(psImage);
+    }
+}
+
+//*****************************************************************************
+//
+//! @brief Execute an image that has already been written to flash.
+//!
+//! @param psImage is a pointer to the image structure.
+//!
+//! This function can be used to "run" a program that has already been
+//! downloaded and written to flash. It does this by reading the initial
+//! stack-pointer and reset vector information from the image written in flash,
+//! writing that information to the relevant registers, and immediately
+//! branching to the new reset vector location.
+//!
+//! Note that this method does not include any type of reset. It is the callers
+//! responsibility to ensure that the MCU is in a valid state for the
+//! subsequent program to run. One way to guarantee this is to run this
+//! function very early after a RESET event, before clocks or peripherals are
+//! configured.
+//!
+//! @return
+//
+//*****************************************************************************
+#if (defined (__ARMCC_VERSION)) && (__ARMCC_VERSION < 6000000)
+__asm void
+am_util_bootloader_encrypted_image_run(am_util_bootloader_image_t *psImage)
+{
+    //
+    // Load the new stack pointer into R1 and the new reset vector into R2.
+    //
+    ldr     r1, [r0, #20]
+    ldr     r2, [r0, #24]
+
+    //
+    // Load the link address of the boot image into R0.
+    //
+    ldr     r0, [r0, #0]
+
+    //
+    // Store the vector table pointer of the new image into VTOR.
+    //
+    movw    r3, #0xED08
+    movt    r3, #0xE000
+    str     r0, [r3, #0]
+
+    //
+    // Set the stack pointer for the new image.
+    //
+    mov     sp, r1
+
+    //
+    // Jump to the new reset vector.
+    //
+    bx      r2
+}
+#elif (defined (__ARMCC_VERSION)) && (__ARMCC_VERSION > 6000000)
+void __attribute__((naked))
+am_util_bootloader_encrypted_image_run(am_util_bootloader_image_t *psImage)
+{
+    //
+    // Load the new stack pointer into R1 and the new reset vector into R2.
+    //
+    __asm("    ldr     r1, [r0, #20]");
+    __asm("    ldr     r2, [r0, #24]");
+
+    //
+    // Load the link address of the boot image into R0.
+    //
+    __asm("    ldr     r0, [r0, #0]");
+
+    //
+    // Store the vector table pointer of the new image into VTOR.
+    //
+    __asm("    movw    r3, #0xED08");
+    __asm("    movt    r3, #0xE000");
+    __asm("    str     r0, [r3, #0]");
+
+    //
+    // Set the stack pointer for the new image.
+    //
+    __asm("    mov     sp, r1");
+
+    //
+    // Jump to the new reset vector.
+    //
+    __asm("    bx      r2");
+}
+#elif defined(__GNUC_STDC_INLINE__)
+void __attribute__((naked))
+am_util_bootloader_encrypted_image_run(am_util_bootloader_image_t *psImage)
+{
+    //
+    // Load the new stack pointer into R1 and the new reset vector into R2.
+    //
+    __asm("    ldr     r1, [r0, #20]");
+    __asm("    ldr     r2, [r0, #24]");
+
+    //
+    // Load the link address of the boot image into R0.
+    //
+    __asm("    ldr     r0, [r0, #0]");
+
+    //
+    // Store the vector table pointer of the new image into VTOR.
+    //
+    __asm("    movw    r3, #0xED08");
+    __asm("    movt    r3, #0xE000");
+    __asm("    str     r0, [r3, #0]");
+
+    //
+    // Set the stack pointer for the new image.
+    //
+    __asm("    mov     sp, r1");
+
+    //
+    // Jump to the new reset vector.
+    //
+    __asm("    bx      r2");
+}
+#elif defined(__IAR_SYSTEMS_ICC__)
+__stackless void
+am_util_bootloader_encrypted_image_run(am_util_bootloader_image_t *psImage)
+{
+    //
+    // Load the new stack pointer into R1 and the new reset vector into R2.
+    //
+    __asm("    ldr     r1, [r0, #20]");
+    __asm("    ldr     r2, [r0, #24]");
+
+    //
+    // Load the link address into R0.
+    //
+    __asm("    ldr     r0, [r0, #0]");
+
+    //
+    // Store the vector table pointer of the new image into VTOR.
+    //
+    __asm("    movw    r3, #0xED08");
+    __asm("    movt    r3, #0xE000");
+    __asm("    str     r0, [r3, #0]");
+
+    //
+    // Set the stack pointer for the new image.
+    //
+    __asm("    mov     sp, r1");
+
+    //
+    // Jump to the new reset vector.
+    //
+    __asm("    bx      r2");
+}
+#endif
+
+//*****************************************************************************
+//
+//! @brief Execute an image that has already been written to flash.
+//!
+//! @param psImage is a pointer to the image structure.
+//!
+//! This function can be used to "run" a program that has already been
+//! downloaded and written to flash. It does this by reading the initial
+//! stack-pointer and reset vector information from the image written in flash,
+//! writing that information to the relevant registers, and immediately
+//! branching to the new reset vector location.
+//!
+//! Note that this method does not include any type of reset. It is the callers
+//! responsibility to ensure that the MCU is in a valid state for the
+//! subsequent program to run. One way to guarantee this is to run this
+//! function very early after a RESET event, before clocks or peripherals are
+//! configured.
+//!
+//! @return
+//
+//*****************************************************************************
+#if defined(__GNUC__) || defined(keil6)
+void __attribute__((naked))
+am_util_bootloader_clear_image_run(am_util_bootloader_image_t *psImage)
+{
+    //
+    // Load the link address of the boot image into R0.
+    //
+    __asm("    ldr     r0, [r0, #0]");
+
+    //
+    // Store the vector table pointer of the new image into VTOR.
+    //
+    __asm("    movw    r3, #0xED08");
+    __asm("    movt    r3, #0xE000");
+    __asm("    str     r0, [r3, #0]");
+
+    //
+    // Load the new stack pointer into R1 and the new reset vector into R2.
+    //
+    __asm("    ldr     r1, [r0, #0]");
+    __asm("    ldr     r2, [r0, #4]");
+
+    //
+    // Set the stack pointer for the new image.
+    //
+    __asm("    mov     sp, r1");
+
+    //
+    // Jump to the new reset vector.
+    //
+    __asm("    bx      r2");
+}
+#elif defined(keil)
+__asm void
+am_util_bootloader_clear_image_run(am_util_bootloader_image_t *psImage)
+{
+    //
+    // Load the link address of the boot image into R0.
+    //
+    ldr     r0, [r0, #0]
+
+    //
+    // Store the vector table pointer of the new image into VTOR.
+    //
+    movw    r3, #0xED08
+    movt    r3, #0xE000
+    str     r0, [r3, #0]
+
+    //
+    // Load the new stack pointer into R1 and the new reset vector into R2.
+    //
+    ldr     r1, [r0, #0]
+    ldr     r2, [r0, #4]
+
+    //
+    // Set the stack pointer for the new image.
+    //
+    mov     sp, r1
+
+    //
+    // Jump to the new reset vector.
+    //
+    bx      r2
+}
+#elif defined(iar)
+__stackless void
+am_util_bootloader_clear_image_run(am_util_bootloader_image_t *psImage)
+{
+    //
+    // Load the link address into R0.
+    //
+    __asm("    ldr     r0, [r0, #0]");
+
+    //
+    // Store the vector table pointer of the new image into VTOR.
+    //
+    __asm("    movw    r3, #0xED08");
+    __asm("    movt    r3, #0xE000");
+    __asm("    str     r0, [r3, #0]");
+
+    //
+    // Load the new stack pointer into R1 and the new reset vector into R2.
+    //
+    __asm("    ldr     r1, [r0, #0]");
+    __asm("    ldr     r2, [r0, #4]");
+
+    //
+    // Set the stack pointer for the new image.
+    //
+    __asm("    mov     sp, r1");
+
+    //
+    // Jump to the new reset vector.
+    //
+    __asm("    bx      r2");
+}
+#endif
+

--- a/utils/am_util_bootloader.c
+++ b/utils/am_util_bootloader.c
@@ -27,7 +27,7 @@
 #define DPRINTF(x)
 #endif
 
-#if defined(AM_PART_APOLLO3) || defined(AM_PART_APOLLO3P)
+#if defined(CONFIG_SOC_SERIES_APOLLO3X)
 const am_hal_gpio_pincfg_t g_AM_HAL_GPIO_INPUT_ENABLE =
 {
   .uFuncSel             = AM_HAL_PIN_0_GPIO,
@@ -280,7 +280,7 @@ am_util_bootloader_flash_check(am_util_bootloader_image_t *psImage)
     //
     // Make sure the link address is in flash.
     //
-#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+#if defined(CONFIG_SOC_SERIES_APOLLO4X)
     if (((AM_HAL_MRAM_ADDR != 0) && (ui32LinkAddress < AM_HAL_MRAM_ADDR)) ||
         (ui32LinkAddress >= (AM_HAL_MRAM_ADDR + sDevice.ui32FlashSize)))
 #else
@@ -307,7 +307,7 @@ am_util_bootloader_flash_check(am_util_bootloader_image_t *psImage)
         ui32ResetVector = (uint32_t) psImage->pui32ResetVector;
     }
 
-#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+#if defined(CONFIG_SOC_SERIES_APOLLO4X)
     //
     // Make sure the stack is in SRAM.
     //
@@ -397,26 +397,22 @@ am_hal_bootloader_override_check(am_util_bootloader_image_t *psImage)
         //
         // Temporarily configure the override pin as an input.
         //
-#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+#if defined(CONFIG_SOC_SERIES_APOLLO4X)
         am_hal_gpio_pinconfig(psImage->ui32OverrideGPIO, am_hal_gpio_pincfg_input);
-#else
-#if defined(AM_PART_APOLLO3) || defined(AM_PART_APOLLO3P)
+#elif defined(CONFIG_SOC_SERIES_APOLLO3X)
         am_hal_gpio_pinconfig(psImage->ui32OverrideGPIO, g_AM_HAL_GPIO_INPUT_ENABLE);
 #else
         am_hal_gpio_pin_config(psImage->ui32OverrideGPIO, AM_HAL_PIN_INPUT);
 #endif
-#endif
         //
         // If the override pin matches the specified polarity, force a failure.
         //
-#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+#if defined(CONFIG_SOC_SERIES_APOLLO4X)
         am_hal_gpio_state_read(psImage->ui32OverrideGPIO, AM_HAL_GPIO_INPUT_READ, &ui32OverridePin );
-#else
-#if defined(AM_PART_APOLLO3) || defined(AM_PART_APOLLO3P)
+#elif defined(CONFIG_SOC_SERIES_APOLLO3X)
         am_hal_gpio_state_read(psImage->ui32OverrideGPIO, AM_HAL_GPIO_INPUT_READ, &ui32OverridePin );
 #else
         ui32OverridePin = am_hal_gpio_input_bit_read(psImage->ui32OverrideGPIO);
-#endif
 #endif
         if ( ui32OverridePin == (psImage->ui32OverridePolarity & 0x1) )
         {
@@ -424,14 +420,12 @@ am_hal_bootloader_override_check(am_util_bootloader_image_t *psImage)
             //
             // Make sure to disable the pin before continuing.
             //
-#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+#if defined(CONFIG_SOC_SERIES_APOLLO4X)
             am_hal_gpio_pinconfig(psImage->ui32OverrideGPIO, am_hal_gpio_pincfg_disabled);
-#else
-#if defined(AM_PART_APOLLO3) || defined(AM_PART_APOLLO3P)
+#elif defined(CONFIG_SOC_SERIES_APOLLO3X)
             am_hal_gpio_pinconfig(psImage->ui32OverrideGPIO, g_AM_HAL_GPIO_INPUT_DISABLE);
 #else
             am_hal_gpio_pin_config(psImage->ui32OverrideGPIO, AM_HAL_PIN_DISABLE);
-#endif
 #endif
             return true;
         }
@@ -447,14 +441,12 @@ am_hal_bootloader_override_check(am_util_bootloader_image_t *psImage)
         // as it might interfere with the program we are (presumably) about to
         // boot.
         //
-#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+#if defined(CONFIG_SOC_SERIES_APOLLO4X)
             am_hal_gpio_pinconfig(psImage->ui32OverrideGPIO, am_hal_gpio_pincfg_disabled);
-#else
-#if defined(AM_PART_APOLLO3) || defined(AM_PART_APOLLO3P)
+#elif defined(CONFIG_SOC_SERIES_APOLLO3X)
             am_hal_gpio_pinconfig(psImage->ui32OverrideGPIO, g_AM_HAL_GPIO_INPUT_DISABLE);
 #else
             am_hal_gpio_pin_config(psImage->ui32OverrideGPIO, AM_HAL_PIN_DISABLE);
-#endif
 #endif
     }
 
@@ -556,7 +548,7 @@ am_util_bootloader_flag_page_update(am_util_bootloader_image_t *psImage,
     // Start a critical section.
     //
     ui32Critical = am_hal_interrupt_master_disable();
-#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+#if defined(CONFIG_SOC_SERIES_APOLLO4X)
     int rc = am_hal_mram_main_program(AM_HAL_MRAM_PROGRAM_KEY,
                               (uint32_t *) psImage,
                               pui32FlagPage,
@@ -642,7 +634,9 @@ am_util_bootloader_check_index(uint32_t index, uint32_t *pMask)
 void
 am_util_bootloader_erase_flash_page(uint32_t ui32Addr)
 {
-#if !defined(AM_PART_APOLLO4) && !defined(AM_PART_APOLLO4B) && !defined(AM_PART_APOLLO4L) && !defined(AM_PART_APOLLO4P)
+#if defined(CONFIG_SOC_SERIES_APOLLO4X)
+    return;
+#else
     uint32_t ui32Critical;
     uint32_t ui32CurrentPage, ui32CurrentBlock;
     //
@@ -695,7 +689,7 @@ am_util_bootloader_write_flash_within_page(uint32_t ui32WriteAddr,
     //
     // Program the flash page with the data we just received.
     //
-#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) ||  defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+#if defined(CONFIG_SOC_SERIES_APOLLO4X)
     am_hal_mram_main_program(AM_HAL_MRAM_PROGRAM_KEY, pui32ReadAddr,
                               (uint32_t *)ui32WriteAddr, ui32NumWords);
 #else
@@ -740,7 +734,7 @@ am_util_bootloader_program_flash_page(uint32_t ui32WriteAddr,
     //
     // Program the flash page with the data we just received.
     //
-#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+#if defined(CONFIG_SOC_SERIES_APOLLO4X)
     am_hal_mram_main_program(AM_HAL_MRAM_PROGRAM_KEY, pui32ReadAddr,
                               (uint32_t *)ui32WriteAddr, ui32WordsInBuffer);
 #else

--- a/utils/am_util_bootloader.h
+++ b/utils/am_util_bootloader.h
@@ -1,0 +1,102 @@
+//*****************************************************************************
+//
+//! @file am_util_bootloader.h
+//!
+//! @brief
+//
+//*****************************************************************************
+
+//*****************************************************************************
+//
+// ${copyright}
+//
+// This is part of revision ${version} of the AmbiqSuite Development Package.
+//
+//*****************************************************************************
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifndef AM_BOOTLOADER_H
+#define AM_BOOTLOADER_H
+
+//*****************************************************************************
+//
+// Macros
+//
+//*****************************************************************************
+#define AM_BOOTLOADER_DISABLE_OVERRIDE_PIN      (0xFFFFFFFF)
+#define AM_BOOTLOADER_OVERRIDE_HIGH             (0x1)
+#define AM_BOOTLOADER_OVERRIDE_LOW              (0x0)
+
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+//*****************************************************************************
+//
+// Structure to keep track of boot image information.
+// In the flash, the structure contains a 4 byte CRC for integrity
+// verification. It needs to be ensured that the size of this structure is
+// not more than AM_HAL_FLASH_PAGE_SIZE bytes
+//
+//*****************************************************************************
+typedef struct
+{
+    // Starting address where the image was linked to run.
+    uint32_t *pui32LinkAddress;
+
+    // Length of the executable image in bytes.
+    uint32_t ui32NumBytes;
+
+    // CRC-32 Value for the full image.
+    uint32_t ui32CRC;
+
+    // Override GPIO number. (Can be used to force a new image load)
+    uint32_t ui32OverrideGPIO;
+
+    // Polarity for the override pin.
+    uint32_t ui32OverridePolarity;
+
+    // Stack pointer location.
+    uint32_t *pui32StackPointer;
+
+    // Reset vector location.
+    uint32_t *pui32ResetVector;
+
+    // Protection status of image in flash
+    uint32_t bEncrypted;
+
+    // CRC-32 value of this structure
+    uint32_t ui32Checksum;
+}
+am_util_bootloader_image_t;
+
+//*****************************************************************************
+//
+// External function declarations.
+//
+//*****************************************************************************
+extern uint32_t am_util_bootloader_crc32(const void *pvData, uint32_t ui32Length);
+extern uint32_t am_util_bootloader_fast_crc32(const void *pvData, uint32_t ui32NumBytes);
+extern void am_util_bootloader_partial_crc32(const void *pvData, uint32_t ui32NumBytes, uint32_t *pui32CRC);
+extern bool am_util_bootloader_image_check(am_util_bootloader_image_t *psImage);
+extern bool am_util_bootloader_flash_check(am_util_bootloader_image_t *psImage);
+extern int am_util_bootloader_flag_page_update(am_util_bootloader_image_t *psImage, uint32_t *pui32FlagPage);
+extern bool am_util_bootloader_validate_structure(uint32_t *pInfo, uint32_t size);
+extern bool am_hal_bootloader_override_check(am_util_bootloader_image_t *psImage);
+extern void am_util_bootloader_image_run(am_util_bootloader_image_t *psImage);
+extern bool am_util_bootloader_check_index(uint32_t index, uint32_t *pMask);
+extern void am_util_bootloader_write_flash_within_page(uint32_t ui32WriteAddr,
+    uint32_t *pui32ReadAddr, uint32_t ui32NumWords);
+
+extern void am_util_bootloader_program_flash_page(uint32_t ui32WriteAddr,
+    uint32_t *pui32ReadAddr, uint32_t numBytes);
+extern void am_util_bootloader_erase_flash_page(uint32_t ui32Addr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // AM_BOOTLOADER_H

--- a/utils/am_util_multi_boot.c
+++ b/utils/am_util_multi_boot.c
@@ -1,0 +1,920 @@
+//*****************************************************************************
+//
+//! @file am_util_multi_boot.c
+//!
+//! @brief Bootloader implementation accepting multiple host protocols.
+//!
+//! This is a bootloader implementation that supports flash programming over
+//! UART, SPI, and I2C. The correct protocol is selected automatically at boot
+//! time. The messaging is expected to follow little-endian format, which is
+//! native to Apollo1/2.
+//!
+//
+//*****************************************************************************
+
+//*****************************************************************************
+//
+// ${copyright}
+//
+// This is part of revision ${version} of the AmbiqSuite Development Package.
+//
+//*****************************************************************************
+#include <string.h>
+#include "am_mcu_apollo.h"
+#include "am_bsp.h"
+#include "am_util.h"
+#include "am_util_multi_boot_private.h"
+#include "am_util_multi_boot.h"
+
+// Protection against NULL pointer
+#define FLASH_OPERATE(pFlash, func) ((pFlash)->func ? (pFlash)->func() : 0)
+
+//*****************************************************************************
+//
+// Message buffers.
+//
+// Note: The RX buffer needs to be 32-bit aligned to be compatible with the
+// flash helper functions, but we also need an 8-bit pointer to it for copying
+// data from the IOS interface, which is only 8 bits wide.
+//
+//*****************************************************************************
+typedef struct
+{
+    uint32_t *pui32UserBuf;
+    uint8_t  *pui8RxBuffer;
+    uint32_t ui32BytesInBuffer;
+    bool     bStoreInSRAM;
+    uint32_t *pui32WriteAddress;
+#ifdef MULTIBOOT_SECURE
+    uint32_t ui32SramBytesUsed;
+#endif
+} am_util_multiboot_t;
+
+static am_util_multiboot_t g_am_util_multiboot = {
+    .pui32UserBuf = NULL,
+    .pui8RxBuffer = NULL,
+    .ui32BytesInBuffer = 0,
+    .bStoreInSRAM = 0,
+    .pui32WriteAddress = 0,
+#ifdef MULTIBOOT_SECURE
+    .ui32SramBytesUsed = 0,
+#endif
+} ;
+
+static bool
+check_flash_address_range(uint32_t address, uint32_t size);
+
+
+//*****************************************************************************
+//
+// Globals to keep track of the image write state.
+//
+//*****************************************************************************
+uint32_t g_ui32BytesReceived = 0;
+uint32_t g_ui32CRC = 0;
+
+//*****************************************************************************
+//
+// Image structure to hold data about the downloaded boot image.
+//
+//*****************************************************************************
+am_util_bootloader_image_t g_sImage =
+{
+    DEFAULT_LINK_ADDRESS,
+    0,
+    0,
+    DEFAULT_OVERRIDE_GPIO,
+    DEFAULT_OVERRIDE_POLARITY,
+    0,
+    0,
+    0
+};
+
+//*****************************************************************************
+//
+// Flag page information.
+//
+//*****************************************************************************
+am_util_bootloader_image_t *g_psBootImage = (am_util_bootloader_image_t *) FLAG_PAGE_LOCATION;
+
+// Checks that the address does not overlap with bootloader or flag page
+// It also checks that the address is inside the internal flash
+static bool
+check_flash_address_range(uint32_t address, uint32_t size)
+{
+    static uint32_t g_intFlashSize = 0;
+    am_hal_mcuctrl_device_t sDevice;
+
+    uint32_t ui32Start = address;
+    uint32_t ui32End = address + size - 1 ;
+
+    if (g_intFlashSize == 0) // First call
+    {
+        // Get chip specific info
+#if defined(AM_PART_APOLLO3_API) || defined(AM_PART_APOLLO4_API) || defined(AM_PART_APOLLO5_API)
+        am_hal_mcuctrl_info_get(AM_HAL_MCUCTRL_INFO_DEVICEID, &sDevice);
+#else
+        am_hal_mcuctrl_device_info_get(&sDevice);
+#endif
+
+#if !defined(AM_PART_APOLLO4B) && !defined(AM_PART_APOLLO4L) &&!defined(AM_PART_APOLLO4P)
+        g_intFlashSize = sDevice.ui32FlashSize;
+#else
+        g_intFlashSize = sDevice.ui32MRAMSize;
+#endif
+    }
+
+    //
+    // Make sure the address is within flash.
+    //
+    //
+    // Check to make sure address is not within bootloader program
+    //
+    if ( ui32Start < MAX_BOOTLOADER_SIZE )
+    {
+        return false;
+    }
+    // Check to make sure the address is not beyond the flash
+    if (ui32End >= g_intFlashSize)
+    {
+        return false;
+    }
+    if ( USE_FLAG_PAGE )
+    {
+        //
+        // Check to make sure address is not in the flag page
+        //
+        if ( (FLAG_PAGE_LOCATION == ui32Start) ||
+             ((FLAG_PAGE_LOCATION < ui32Start) &&
+                ((FLAG_PAGE_LOCATION + AM_HAL_FLASH_PAGE_SIZE) > ui32Start)) ||
+            ((FLAG_PAGE_LOCATION > ui32Start) &&
+                (FLAG_PAGE_LOCATION <= ui32End))
+           )
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+//*****************************************************************************
+//
+// Internal Flash handler wrapper
+//
+//*****************************************************************************
+static int
+am_util_multiboot_flash_read_page(uint32_t ui32DestAddr, uint32_t *pSrc, uint32_t ui32Length)
+{
+    if (check_flash_address_range((uint32_t)pSrc, ui32Length))
+    {
+        memcpy((uint8_t *)ui32DestAddr, (uint8_t *)pSrc, ui32Length);
+        return 0;
+    }
+    else
+    {
+        return -1;
+    }
+}
+
+static int
+am_util_multiboot_flash_write_page(uint32_t ui32DestAddr, uint32_t *pSrc, uint32_t ui32Length)
+{
+    if (check_flash_address_range(ui32DestAddr, ui32Length))
+    {
+        am_util_bootloader_program_flash_page(ui32DestAddr, pSrc, ui32Length);
+        return 0;
+    }
+    else
+    {
+        return -1;
+    }
+}
+
+
+static int am_util_multiboot_flash_erase_page(uint32_t ui32DestAddr)
+{
+    if (check_flash_address_range(ui32DestAddr, 4))
+    {
+        am_util_bootloader_erase_flash_page(ui32DestAddr);
+        return 0;
+    }
+    else
+    {
+        return -1;
+    }
+}
+
+am_util_multiboot_flash_info_t g_intFlash =
+{
+    // flagPageSize could be set as small as 4 Bytes, and as large as
+    // AM_HAL_FLASH_PAGE_SIZE, since Read/Write on internal flash are
+    // allowed at 4 byte granularity
+    // It is set to max for power optimization
+    // This may have indirect impact on temp storage needed, so it can
+    // be reduced as a trade-off
+    .flashPageSize      = AM_HAL_FLASH_PAGE_SIZE,
+    .flashSectorSize    = AM_HAL_FLASH_PAGE_SIZE,
+    .flash_init         = NULL,
+    .flash_deinit       = NULL,
+    .flash_enable       = NULL,
+    .flash_disable      = NULL,
+    .flash_read_page    = am_util_multiboot_flash_read_page,
+    .flash_write_page   = am_util_multiboot_flash_write_page,
+    .flash_erase_sector = am_util_multiboot_flash_erase_page,
+};
+
+am_util_multiboot_flash_info_t *g_pFlashInfo;
+uint32_t *g_pTempBuf;
+
+#ifdef MULTIBOOT_SECURE
+// Wipe Clean SRAM up to the specified address
+// CAUTION!!!
+// This will wipe the complete SRAM including stack of the caller
+// This should be called as the last thing before calling reset
+void wipe_sram(void)
+{
+    //
+    // Wipe SRAM (without using variables).
+    //
+    // Use the first SRAM location as temp
+    // Last SRAM word = lastAddr = SRAM_BASEADDR + g_am_util_multiboot.ui32SramBytesUsed - 4;
+    *((volatile uint32_t *)(SRAM_BASEADDR)) =
+        SRAM_BASEADDR + g_am_util_multiboot.ui32SramBytesUsed - 4;
+
+    // Can not use any local variables from now on
+    while ( *((volatile uint32_t *)(SRAM_BASEADDR)) != SRAM_BASEADDR )
+    {
+        *(*((volatile uint32_t **)(SRAM_BASEADDR))) = 0x0;
+        *((volatile uint32_t *)(SRAM_BASEADDR)) -= 4;
+    }
+}
+#endif
+
+// Programs the flash based on g_am_util_multiboot.pui32WriteAddress, g_am_util_multiboot.pui8RxBuffer & g_am_util_multiboot.ui32BytesInBuffer
+void
+program_image(uint32_t bEncrypted)
+{
+    uint32_t ui32WriteAddr = (uint32_t)g_am_util_multiboot.pui32WriteAddress;
+    uint32_t *pui32ReadAddr = (uint32_t *)g_am_util_multiboot.pui8RxBuffer;
+    uint32_t ui32NumBytes = g_am_util_multiboot.ui32BytesInBuffer;
+
+    if ( g_am_util_multiboot.bStoreInSRAM )
+    {
+        while ( ui32NumBytes )
+        {
+            am_util_bootloader_program_flash_page(ui32WriteAddr, pui32ReadAddr,
+                (ui32NumBytes > AM_HAL_FLASH_PAGE_SIZE) ? AM_HAL_FLASH_PAGE_SIZE: ui32NumBytes);
+            if ( ui32NumBytes > AM_HAL_FLASH_PAGE_SIZE )
+            {
+                ui32NumBytes -= AM_HAL_FLASH_PAGE_SIZE;
+                ui32WriteAddr += AM_HAL_FLASH_PAGE_SIZE;
+                pui32ReadAddr += AM_HAL_FLASH_PAGE_SIZE / 4;
+            }
+            else
+            {
+                break;
+            }
+        }
+    }
+// #### INTERNAL BEGIN ####
+    // TODO: Apply necessary protections to flash
+    // Need to add flash protection - chunk by chunk including potentially
+    // the last partial chunk
+// #### INTERNAL END ####
+}
+
+//*****************************************************************************
+//
+//! @brief Initialize multiboot
+//!
+//! @param pBuf is the temporary buffer for multiboot to operate on. This should
+//! be at least equal to the AM_HAL_FLASH_PAGE_SIZE
+//! @param bufSize is the temporary buffer size
+//!
+//! This function provides multiboot with the scratch memory in SRAM
+//!
+//! @return true if the parameters are acceptable.
+//
+//*****************************************************************************
+bool
+am_util_multiboot_init(uint32_t *pBuf, uint32_t bufSize)
+{
+    bool ret = false;
+    if (pBuf && (bufSize >= AM_HAL_FLASH_PAGE_SIZE))
+    {
+        g_am_util_multiboot.pui32UserBuf = pBuf;
+        ret = true;
+    }
+    return ret;
+}
+
+//*****************************************************************************
+//
+//! @brief Read an image start packet
+//!
+//! @param psImage is the image structure to read the packet into.
+//!
+//! This function reads the "new image" packet, and uses that
+//! packet to fill in a bootloader image structure. The caller is responsible
+//! for verifying the packet type before calling this function.
+//! Packet Structure:
+//! word0 = Link Address
+//! word1 = Number of Bytes (Image Size)
+//! word2 = CRC
+//! ENCRYPTED?? (#ifdef MULTIBOOT_SECURE)
+//! word3 = Security Trailer Length
+//!
+//! @return true if the image parameters are acceptable.
+//
+//*****************************************************************************
+bool
+image_start_packet_read(am_util_bootloader_image_t *psImage, uint32_t *pui32Packet)
+{
+    am_hal_mcuctrl_device_t sDevice;
+
+    // Get chip specific info
+#if defined(AM_PART_APOLLO3_API) || defined(AM_PART_APOLLO4_API) || defined(AM_PART_APOLLO5_API)
+    am_hal_mcuctrl_info_get(AM_HAL_MCUCTRL_INFO_DEVICEID, &sDevice);
+#else
+    // Get chip specific info
+    am_hal_mcuctrl_device_info_get(&sDevice);
+#endif
+
+    //
+    // Set the image structure parameters based on the information in the
+    // packet.
+    //
+    psImage->pui32LinkAddress = (uint32_t *)(pui32Packet[1]);
+    psImage->ui32NumBytes = pui32Packet[2];
+    psImage->ui32CRC = pui32Packet[3];
+    psImage->ui32OverrideGPIO = DEFAULT_OVERRIDE_GPIO;
+    psImage->ui32OverridePolarity = DEFAULT_OVERRIDE_POLARITY;
+    psImage->bEncrypted = 0; // This only indicates Copy-Protection in flash
+
+    //
+    // We'll need to fill in the stack pointer and reset vector a little later
+    // in the process.
+    //
+    psImage->pui32StackPointer = 0;
+    psImage->pui32ResetVector = 0;
+
+    //
+    // Check to make sure we're not overwriting the bootloader or the flag page.
+    //
+    if (!check_flash_address_range((uint32_t)psImage->pui32LinkAddress,
+            psImage->ui32NumBytes))
+    {
+        return false;
+    }
+    // Determine if we can gather image in SRAM completely before flashing all at once
+    // This implementation uses the excess SRAM available in the system
+    // CAUTION!!!: For this to work it is essential that the unused SRAM banks are
+    // not powered down
+#if defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P)
+    if ((sDevice.ui32DTCMSize - MAX_SRAM_USED) >= psImage->ui32NumBytes)
+#else
+    if ((sDevice.ui32SRAMSize - MAX_SRAM_USED) >= psImage->ui32NumBytes)
+#endif
+    {
+        g_am_util_multiboot.bStoreInSRAM = 1;
+        g_am_util_multiboot.pui8RxBuffer = (uint8_t *)(SRAM_BASEADDR + MAX_SRAM_USED);
+#ifdef MULTIBOOT_SECURE
+        g_am_util_multiboot.ui32SramBytesUsed = sDevice.ui32SRAMSize;
+#endif
+    }
+    else
+    {
+        g_am_util_multiboot.bStoreInSRAM = 0;
+        if (g_am_util_multiboot.pui32UserBuf == NULL)
+        {
+            return false;
+        }
+        g_am_util_multiboot.pui8RxBuffer = (uint8_t *)g_am_util_multiboot.pui32UserBuf;
+#ifdef MULTIBOOT_SECURE
+        g_am_util_multiboot.ui32SramBytesUsed = MAX_SRAM_USED;
+#endif
+    }
+
+#ifdef MULTIBOOT_SECURE
+    // Validate the security trailer & Initialize the security params
+    if ( init_multiboot_secure(pui32Packet[4], &pui32Packet[5], g_am_util_multiboot.bStoreInSRAM,
+                               psImage, &psImage->bEncrypted) != 0 )
+    {
+        return false;
+    }
+#endif
+    //
+    // Otherwise, the image is presumed to be reasonable. Set our global
+    // variables based on the new image structure.
+    //
+    g_am_util_multiboot.pui32WriteAddress = psImage->pui32LinkAddress;
+    g_ui32BytesReceived = 0;
+    g_am_util_multiboot.ui32BytesInBuffer = 0;
+    g_ui32CRC = 0;
+    return true;
+}
+
+//*****************************************************************************
+//
+//! @brief Read an image start packet
+//!
+//! @param psImage is the image structure to read the packet into.
+//!
+//! This function reads the "new image" packet, and uses that
+//! packet to fill in a bootloader image structure. The caller is responsible
+//! for verifying the packet type before calling this function.
+//!
+//! @return None.
+//
+//*****************************************************************************
+void
+image_data_packet_read(uint8_t *pui8Src, uint32_t ui32Size)
+{
+    uint32_t i;
+    //
+    // Loop through the data, copying it into the global buffer.
+    //
+    for ( i = 0; i < ui32Size; i++ )
+    {
+        g_am_util_multiboot.pui8RxBuffer[g_am_util_multiboot.ui32BytesInBuffer] = *pui8Src++;
+
+        //
+        // Keep track of how much data we've copied into the SRAM buffer.
+        //
+        g_am_util_multiboot.ui32BytesInBuffer++;
+        g_ui32BytesReceived++;
+
+        //
+        // Whenever we hit a page boundary or the end of the image, we should
+        // write to flash.
+        //
+        if ( (!g_am_util_multiboot.bStoreInSRAM && (g_am_util_multiboot.ui32BytesInBuffer == AM_HAL_FLASH_PAGE_SIZE)) ||
+                 g_ui32BytesReceived == g_sImage.ui32NumBytes )
+        {
+            //
+            // Run a quick CRC on the received bytes, holding on to the result in a
+            // global variable, so we can pick up where we left off on the next pass.
+            //
+            am_util_bootloader_partial_crc32(g_am_util_multiboot.pui8RxBuffer, g_am_util_multiboot.ui32BytesInBuffer, &g_ui32CRC);
+
+#ifdef MULTIBOOT_SECURE
+            // Decrypt in place
+            multiboot_secure_decrypt(g_am_util_multiboot.pui8RxBuffer, g_am_util_multiboot.ui32BytesInBuffer);
+#endif
+
+            //
+            // If this is the first block of our new image, we need to record
+            // the reset vector and stack pointer information for inclusion in
+            // the flag page.
+            //
+            if ( g_am_util_multiboot.bStoreInSRAM || (g_ui32BytesReceived <= AM_HAL_FLASH_PAGE_SIZE) )
+            {
+                g_sImage.pui32StackPointer = (uint32_t *)(((uint32_t *)g_am_util_multiboot.pui8RxBuffer)[0]);
+                g_sImage.pui32ResetVector = (uint32_t *)(((uint32_t *)g_am_util_multiboot.pui8RxBuffer)[1]);
+            }
+
+            if ( !g_am_util_multiboot.bStoreInSRAM )
+            {
+                am_util_bootloader_program_flash_page((uint32_t)g_am_util_multiboot.pui32WriteAddress,
+                    (uint32_t *)g_am_util_multiboot.pui8RxBuffer, g_am_util_multiboot.ui32BytesInBuffer);
+                //
+                // Adjust the global variables.
+                //
+                g_am_util_multiboot.pui32WriteAddress += (g_am_util_multiboot.ui32BytesInBuffer / 4);
+                g_am_util_multiboot.ui32BytesInBuffer = 0;
+            }
+        }
+    }
+}
+
+//*****************************************************************************
+//
+//! @brief Check if we should be booting from flash with a valid image
+//!
+//! @param pbOverride is the return parameter, used to pass back the override status
+//! @param ppsImage is the return parameter, used to pass back the image structure.
+//!
+//! This function checks the flag page (if enabled) and verifies the flash image
+//! for integrity. It also checks for the override pin status in case forced
+//! host boot is requested..
+//!
+//! @return true if it's okay to boot from flash (returns the image structure).
+//
+//*****************************************************************************
+bool
+am_util_multiboot_check_boot_from_flash(bool *pbOverride, am_util_bootloader_image_t **ppsImage)
+{
+    bool bValid = false;
+    //
+    // If we're using a flag page, we can run a full CRC check to verify the
+    // integrity of our image. If not, we'll just check the override pin.
+    // First check if the flag page is valid
+    //
+    if ( USE_FLAG_PAGE &&
+        ( am_util_bootloader_validate_structure((uint32_t *)g_psBootImage, sizeof(*g_psBootImage)) ))
+    {
+        //##### INTERNAL BEGIN #####
+        // Update Active Image status - possibly based on the reset reason?
+        // Update Active/Backup if needed
+        // Check for new image segment(s) avialability for flashing
+        // Proceed with Authentication, Validation and Flashing of new image segment(s)
+        // Update Flag Page as needed (Mark Active as Backup, mark new image as Active)
+        // if the first image segment is updated
+        //##### INTERNAL END #####
+        //
+        // Check the flag page (including the stored CRC) and the override pin
+        // to make sure we have a valid image and the host isn't requesting an
+        // upgrade.
+        //
+        if (am_hal_bootloader_override_check(g_psBootImage))
+        {
+            *pbOverride = true;
+        }
+        else
+        {
+            *pbOverride = false;
+            if ( am_util_bootloader_flash_check(g_psBootImage) )
+            {
+                *ppsImage = g_psBootImage;
+                bValid = true;
+            }
+            //##### INTERNAL BEGIN #####
+            else
+            {
+                // Update Active/Backup if possible - mark Backup as Active and invalidate Active
+                // Try booting with Backup
+            }
+            //##### INTERNAL END #####
+        }
+    }
+    else
+    {
+        //
+        // Check the override pin to make sure the host isn't requesting an
+        // upgrade, and do a quick check to make sure an image actually exists
+        // at the default application location.
+        //
+        if (am_hal_bootloader_override_check(&g_sImage))
+        {
+            *pbOverride = true;
+        }
+        else
+        {
+            *pbOverride = false;
+            if ( *(g_sImage.pui32LinkAddress) != 0xFFFFFFFF)
+            {
+                *ppsImage = &g_sImage;
+                bValid = true;
+            }
+        }
+    }
+    return bValid;
+}
+
+
+// Erases the flash based on ui32Addr & ui32NumBytes
+void
+erase_ota_image(uint32_t ui32Addr, uint32_t ui32NumBytes, am_util_multiboot_flash_info_t *pFlash)
+{
+    // Erase the image
+    while ( ui32NumBytes )
+    {
+        pFlash->flash_erase_sector(ui32Addr);
+        if ( ui32NumBytes > pFlash->flashSectorSize )
+        {
+            ui32NumBytes -= pFlash->flashSectorSize;
+            ui32Addr += pFlash->flashSectorSize;
+        }
+        else
+        {
+            break;
+        }
+    }
+}
+
+// Can write across pages
+// The write address should be page aligned & the length in multiple of page size
+int
+write_to_flash(uint32_t ui32DestAddr, uint32_t *pSrc, uint32_t ui32Length, am_util_multiboot_flash_info_t *pFlash)
+{
+    if (ui32DestAddr & (pFlash->flashPageSize - 1))
+    {
+        return -1 ;
+    }
+    while (ui32Length)
+    {
+        uint32_t ui32BytesInPage =
+            (ui32Length > pFlash->flashPageSize) ? \
+                pFlash->flashPageSize : ui32Length;
+        // Writes are always page size
+        pFlash->flash_write_page(ui32DestAddr, pSrc, pFlash->flashPageSize);
+        pSrc += ui32BytesInPage / 4;
+        ui32Length -= ui32BytesInPage;
+        ui32DestAddr += ui32BytesInPage;
+    }
+    return 0;
+}
+
+// Can read across pages
+int
+read_from_flash(uint32_t ui32DestAddr, uint32_t *pSrc, uint32_t ui32Length, am_util_multiboot_flash_info_t *pFlash)
+{
+    uint32_t ui32Preceding = (uint32_t)pSrc & (pFlash->flashPageSize - 1);
+    while (ui32Length)
+    {
+        uint32_t ui32BytesInPage =
+            ((ui32Preceding + ui32Length) > pFlash->flashPageSize) ? \
+                (pFlash->flashPageSize - ui32Preceding) : ui32Length;
+        pFlash->flash_read_page(ui32DestAddr, pSrc, ui32BytesInPage);
+        pSrc += ui32BytesInPage / 4;
+        ui32Length -= ui32BytesInPage;
+        ui32DestAddr += ui32BytesInPage;
+        ui32Preceding = 0;
+    }
+    return 0;
+}
+
+
+// We can not read and program the same flash bank
+// So - we need to first copy data to SRAM, and then flash...block by block
+static void
+program_image_from_flash(uint32_t ui32WriteAddr, uint32_t *pui32ReadAddr,
+                         uint32_t ui32NumBytes, bool bDecrypt,
+                         am_util_multiboot_flash_info_t *pReadFlash,
+                         am_util_multiboot_flash_info_t *pWriteFlash)
+{
+    uint32_t ui32NumBytesInPage;
+    uint32_t *pStart = g_pTempBuf;
+    // Determine the preceding data bytes at the destination page
+    uint32_t ui32PrecedingBytes = ui32WriteAddr & (pWriteFlash->flashSectorSize - 1);
+    // Flash Write can only happen in terms of pages
+    // So, if the image does not start on page boundary - need to take proper precautions
+    // to preserve other data in the page
+    if (ui32PrecedingBytes)
+    {
+        // Page aligned
+        ui32WriteAddr &= ~(pWriteFlash->flashSectorSize - 1);
+        // Copy the preceding content at destination page in buffer
+        read_from_flash((uint32_t)g_pTempBuf, (uint32_t *)ui32WriteAddr, ui32PrecedingBytes, pWriteFlash);
+    }
+    while ( ui32NumBytes )
+    {
+        pStart = g_pTempBuf + ui32PrecedingBytes / 4;
+        if ((ui32PrecedingBytes + ui32NumBytes) > pWriteFlash->flashSectorSize)
+        {
+            ui32NumBytesInPage = pWriteFlash->flashSectorSize - ui32PrecedingBytes;
+        }
+        else
+        {
+            // Last sector to be written
+            ui32NumBytesInPage = ui32NumBytes;
+            if ((ui32NumBytesInPage + ui32PrecedingBytes) != pWriteFlash->flashSectorSize)
+            {
+                // Copy the trailing content at destination page in buffer
+                read_from_flash((uint32_t)pStart + ui32NumBytesInPage,
+                                pui32ReadAddr + ui32NumBytesInPage / 4,
+                                pWriteFlash->flashSectorSize - (ui32NumBytesInPage + ui32PrecedingBytes),
+                                pWriteFlash);
+            }
+        }
+        // Read the image data from source
+        read_from_flash((uint32_t)pStart, pui32ReadAddr, ui32NumBytesInPage, pReadFlash);
+#ifdef MULTIBOOT_SECURE
+        if (bDecrypt)
+        {
+            // Decrypt in place
+            multiboot_secure_decrypt(pStart, ui32NumBytesInPage);
+        }
+#endif
+        // erase the sector
+        pWriteFlash->flash_erase_sector(ui32WriteAddr);
+        // Write the flash sector
+        write_to_flash(ui32WriteAddr, g_pTempBuf, pWriteFlash->flashSectorSize, pWriteFlash);
+
+        ui32WriteAddr += pWriteFlash->flashSectorSize;
+        pui32ReadAddr += ui32NumBytesInPage / 4;
+        ui32NumBytes -= ui32NumBytesInPage;
+        ui32PrecedingBytes = 0;
+    }
+}
+
+//*****************************************************************************
+//
+//! @brief Multiboot protocol handler for OTA update
+//!
+//! @param pOtaInfo is the pointer to OTA descriptor with image information
+//! @param pTempBuf is the pointer to a temporary buffer, sized to one flash
+//! page (bigger of internal and external flash page, if ext flash is being used)
+//! @param invalidateOtaFunc is the function called to invalidate the OTA for
+//! subsequent boots
+//! @param pExtFlash is the pointer external flash access info if needed
+//!
+//! This function validates the OTA blob, and installs the image if verified.
+//! It updates the flag page with the new image information and issues a POI
+//!
+//! @return false if OTA upgrade fails. Otherwise this function does not return
+//
+//*****************************************************************************
+bool
+am_util_multiboot_ota_handler(am_util_multiboot_ota_t *pOtaInfo, uint32_t *pTempBuf,
+                         uint32_t tempBufSize, invalidate_ota_func_t invalidateOtaFunc,
+                         am_util_multiboot_flash_info_t *pExtFlash)
+{
+    am_util_bootloader_image_t *psImage = &g_sImage;
+    am_util_multiboot_flash_info_t *pFlash;
+
+    if ((pTempBuf == NULL) || (pOtaInfo == NULL) || (pOtaInfo->magicNum != OTA_INFO_MAGIC_NUM))
+    {
+        return false;
+    }
+
+    // Validate the contents
+    if ( !am_util_bootloader_validate_structure((uint32_t *)pOtaInfo, sizeof(*pOtaInfo)) )
+    {
+        return false;
+    }
+
+    //
+    // Check to make sure we're not overwriting the bootloader or the flag page.
+    //
+    if (!check_flash_address_range((uint32_t)pOtaInfo->pui32LinkAddress,
+        pOtaInfo->ui32NumBytes))
+    {
+        return false;
+    }
+    // Validate the ext flash info
+    if (pOtaInfo->ui32Options & OTA_INFO_OPTIONS_EXT_FLASH)
+    {
+        if (pExtFlash && pExtFlash->flash_read_page &&
+            pExtFlash->flash_write_page && pExtFlash->flash_erase_sector &&
+            (pExtFlash->flashSectorSize <= tempBufSize))
+        {
+            pFlash = pExtFlash;
+        }
+        else
+        {
+            return false;
+        }
+    }
+    else
+    {
+        // Validate the address and the temp buf size
+        if (g_intFlash.flashSectorSize > tempBufSize)
+        {
+            return false;
+        }
+        pFlash = &g_intFlash;
+    }
+
+    g_pTempBuf = pTempBuf;
+
+    //
+    // Set the image structure parameters based on the information in the
+    // packet.
+    //
+    psImage->pui32LinkAddress = pOtaInfo->pui32LinkAddress;
+    psImage->ui32NumBytes = pOtaInfo->ui32NumBytes;
+    psImage->ui32CRC = pOtaInfo->ui32ImageCrc;
+    psImage->ui32OverrideGPIO = DEFAULT_OVERRIDE_GPIO;
+    psImage->ui32OverridePolarity = DEFAULT_OVERRIDE_POLARITY;
+    psImage->bEncrypted = 0; // This only indicates Copy-Protection in flash
+
+    //
+    // We'll need to fill in the stack pointer and reset vector a little later
+    // in the process.
+    //
+    psImage->pui32StackPointer = 0;
+    psImage->pui32ResetVector = 0;
+
+    g_am_util_multiboot.bStoreInSRAM = 0;
+
+    g_am_util_multiboot.pui8RxBuffer = (uint8_t *)pOtaInfo->pui32ImageAddr;
+    g_am_util_multiboot.ui32BytesInBuffer = pOtaInfo->ui32NumBytes;
+
+    if (FLASH_OPERATE(pFlash, flash_init) == 0)
+    {
+        if (FLASH_OPERATE(pFlash, flash_enable) != 0)
+        {
+            FLASH_OPERATE(pFlash, flash_deinit);
+        }
+    }
+    else
+    {
+        return false;
+    }
+#ifdef MULTIBOOT_SECURE
+    g_am_util_multiboot.ui32SramBytesUsed = MAX_SRAM_USED;
+    // Validate the security trailer & Initialize the security params
+    // CAUTION: If the secInfo is in ext flash, it is assumed that the function would
+    // have means to access it within
+    // Ambiq OTA copies the secInfo always in internal flash, so that would not be
+    // an issue
+    if ( init_multiboot_secure(pOtaInfo->secInfoLen, pOtaInfo->pui32SecInfoPtr,
+                1, psImage, &psImage->bEncrypted) != 0 )
+    {
+        FLASH_OPERATE(pFlash, flash_disable);
+        FLASH_OPERATE(pFlash, flash_deinit);
+        return false;
+    }
+    // Decrypt page by page
+    program_image_from_flash((uint32_t)pOtaInfo->pui32ImageAddr, pOtaInfo->pui32ImageAddr,
+        pOtaInfo->ui32NumBytes, true, pFlash, pFlash);
+    // Verify
+    if ( multiboot_secure_verify(&psImage->ui32CRC) )
+    {
+        // Erase the OTA image
+        erase_ota_image((uint32_t)pOtaInfo->pui32ImageAddr, pOtaInfo->ui32NumBytes, pFlash);
+        FLASH_OPERATE(pFlash, flash_disable);
+        FLASH_OPERATE(pFlash, flash_deinit);
+        return false;
+    }
+#endif
+    psImage->pui32StackPointer = (uint32_t *)(((uint32_t *)pOtaInfo->pui32ImageAddr)[0]);
+    psImage->pui32ResetVector = (uint32_t *)(((uint32_t *)pOtaInfo->pui32ImageAddr)[1]);
+
+    //
+    // The image is presumed to be reasonable. Set our global
+    // variables based on the new image structure.
+    //
+    g_am_util_multiboot.pui32WriteAddress = psImage->pui32LinkAddress;
+
+    program_image_from_flash((uint32_t)pOtaInfo->pui32LinkAddress, pOtaInfo->pui32ImageAddr,
+        pOtaInfo->ui32NumBytes, false, pFlash, &g_intFlash);
+    // Protect the image if needed
+    program_image(psImage->bEncrypted);
+    if ( !(pOtaInfo->ui32Options & OTA_INFO_OPTIONS_DATA) && USE_FLAG_PAGE )
+    {
+        //
+        // Write the flag page.
+        //
+        am_util_bootloader_flag_page_update(&g_sImage, (uint32_t *)FLAG_PAGE_LOCATION);
+    }
+    if (invalidateOtaFunc)
+    {
+        invalidateOtaFunc(pOtaInfo);
+    }
+#ifdef MULTIBOOT_SECURE
+    // Erase the OTA image
+    // Special handling for the case when the install address overlaps with the OTA image
+    // We need to add special handling so as to now erase part of freshly installed image
+    if (((uint32_t)pOtaInfo->pui32LinkAddress < (uint32_t)pOtaInfo->pui32ImageAddr) &&
+        ((uint32_t)pOtaInfo->pui32LinkAddress + pOtaInfo->ui32NumBytes > (uint32_t)pOtaInfo->pui32ImageAddr))
+    {
+        uint32_t skipBytes = (uint32_t)pOtaInfo->pui32LinkAddress + pOtaInfo->ui32NumBytes - (uint32_t)pOtaInfo->pui32ImageAddr;
+        // Multiple of sector size
+        skipBytes = (skipBytes + pFlash->flashSectorSize - 1) & ~(pFlash->flashSectorSize - 1);
+        erase_ota_image((uint32_t)pOtaInfo->pui32ImageAddr + skipBytes, pOtaInfo->ui32NumBytes - skipBytes, pFlash);
+    }
+    else
+    {
+        erase_ota_image((uint32_t)g_am_util_multiboot.pui8RxBuffer, g_am_util_multiboot.ui32BytesInBuffer, pFlash);
+    }
+    wipe_sram();
+#endif
+    //
+    // Perform a software reset.
+    //
+#if (defined(AM_PART_APOLLO3) || defined(AM_PART_APOLLO3P) || defined(AM_PART_APOLLO4) || defined(AM_PART_APOLLO4B) || defined(AM_PART_APOLLO4L) || defined(AM_PART_APOLLO4P))
+    am_hal_reset_control(AM_HAL_RESET_CONTROL_SWPOI, 0);
+#else
+    am_hal_reset_poi();
+#endif
+
+    // Should never reach here
+    return true;
+}
+
+
+//*****************************************************************************
+//
+//! @brief Get the information about the main image
+//!
+//! @param pui32LinkAddr - Used to return the link address for main image
+//! @param pui32Length - Used to return the length of the image
+//!
+//! This function is used to determine attributes of the main image currently
+//! in flash
+//!
+//! @return false if there is no valid flag page
+//
+//*****************************************************************************
+bool
+am_util_multiboot_get_main_image_info(uint32_t *pui32LinkAddr, uint32_t *pui32Length)
+{
+    bool bValid = false;
+    //
+    // If we're using a flag page, we can run a full CRC check to verify the
+    // integrity of our image. If not, we'll just check the override pin.
+    //
+    if ( USE_FLAG_PAGE )
+    {
+        // First check if the flag page is valid
+        if ( am_util_bootloader_validate_structure((uint32_t *)g_psBootImage, sizeof(*g_psBootImage)) )
+        {
+            *pui32LinkAddr = (uint32_t)g_psBootImage->pui32LinkAddress;
+            *pui32Length = g_psBootImage->ui32NumBytes;
+            bValid = true;
+        }
+    }
+    return bValid;
+}

--- a/utils/am_util_multi_boot.h
+++ b/utils/am_util_multi_boot.h
@@ -1,0 +1,111 @@
+//*****************************************************************************
+//
+//! @file am_util_multi_boot.h
+//!
+//! @brief Prototype for Multi Protocol Bootloader implementation
+//!
+//! This is a bootloader program that supports flash programming over UART,
+//! SPI, and I2C. The correct protocol is selected automatically at boot time.
+//!
+//! SWO is configured in 1M baud, 8-n-1 mode.
+//
+//*****************************************************************************
+
+//*****************************************************************************
+//
+// ${copyright}
+//
+// This is part of revision ${version} of the AmbiqSuite Development Package.
+//
+//*****************************************************************************
+
+#ifndef AM_MULTI_BOOT_H
+#define AM_MULTI_BOOT_H
+
+#include "am_mcu_apollo.h"
+#include "am_util_bootloader.h"
+
+// All functions return 0 on success
+typedef int (*flash_read_func_t)(uint32_t ui32DestAddr, uint32_t *pSrc, uint32_t ui32Length);
+typedef int (*flash_write_func_t)(uint32_t ui32DestAddr, uint32_t *pSrc, uint32_t ui32Length);
+typedef int (*flash_erase_func_t)(uint32_t ui32Addr);
+typedef int (*flash_init_func_t)(void);
+typedef int (*flash_deinit_func_t)(void);
+typedef int (*flash_enable_func_t)(void);
+typedef int (*flash_disable_func_t)(void);
+
+typedef struct
+{
+    // Granularity for Write
+    // Should be power of 2
+    uint32_t                flashPageSize;
+    // Granularity for Erase
+    // Should be power of 2
+    uint32_t                flashSectorSize;
+    // Initialize the flash device
+    flash_init_func_t       flash_init;
+    // De-Initialize the flash device
+    flash_deinit_func_t     flash_deinit;
+    // Enable (Power up) the flash device
+    flash_enable_func_t     flash_enable;
+    // Disable (Put in Low power mode) the flash device
+    flash_disable_func_t    flash_disable;
+    // Read a block of data from within a flash page
+    flash_read_func_t       flash_read_page;
+    // Read a block of data within a flash page
+    flash_write_func_t      flash_write_page;
+    // Erase the flash sector corresponding to address specified
+    flash_erase_func_t      flash_erase_sector;
+} am_util_multiboot_flash_info_t;
+
+#define OTA_INFO_OPTIONS_EXT_FLASH  0x1
+#define OTA_INFO_OPTIONS_DATA       0x2
+#define OTA_INFO_MAGIC_NUM          0xDEADCAFE
+typedef struct
+{
+    // Should be set to OTA_INFO_MAGIC_NUM
+    uint32_t    magicNum;
+    // Address in flash where the new image should be programmed
+    uint32_t    *pui32LinkAddress;
+    // Length of image blob
+    uint32_t    ui32NumBytes;
+    // CRC of the image blob
+    uint32_t    ui32ImageCrc;
+    // (Optional) Security Info length
+    uint32_t    secInfoLen;
+    // Options - e.g. Read from external flash device
+    uint32_t    ui32Options;
+    // (optional) Security Information location
+    uint32_t    *pui32SecInfoPtr;
+    // Location of image blob - Address needs to be aligned to 4 Byte address
+    uint32_t    *pui32ImageAddr;
+    // CRC to confirm integrity of the OTA Descriptor structure
+    uint32_t    ui32Crc;
+} am_util_multiboot_ota_t;
+
+typedef void (*invalidate_ota_func_t)(am_util_multiboot_ota_t *pOtaInfo);
+
+
+// Internal flash info and handlers
+extern am_util_multiboot_flash_info_t g_intFlash;
+
+extern bool am_util_multiboot_init(uint32_t *pBuf, uint32_t bufSize);
+
+extern void am_util_multiboot_uart_isr_handler(uint32_t ui32Module);
+extern uint32_t am_util_multiboot_uart_detect_baudrate(uint32_t ui32RxPin);
+extern void am_util_multiboot_setup_serial(int32_t i32Module, uint32_t ui32BaudRate);
+
+extern void am_util_multiboot_ios_acc_isr_handler(void);
+extern void am_util_multiboot_setup_ios_interface(uint32_t interruptPin);
+extern void am_util_multiboot_cleanup_ios_interface(void);
+
+// pExtFlash - can be NULL if using internal flash
+// pTempBuf should point to a memory big enough to hold one flash sector (int or ext) worth of data
+extern bool am_util_multiboot_ota_handler(am_util_multiboot_ota_t *pOtaInfo, uint32_t *pTempBuf,
+                                     uint32_t tempBufSize, invalidate_ota_func_t invalidateOtaFunc,
+                                     am_util_multiboot_flash_info_t *pExtFlash);
+
+extern bool am_util_multiboot_check_boot_from_flash(bool *pbOverride, am_util_bootloader_image_t **ppsImage);
+extern bool am_util_multiboot_get_main_image_info(uint32_t *pui32LinkAddr, uint32_t *pui32Length);
+
+#endif // AM_MULTI_BOOT_H

--- a/utils/am_util_multi_boot_private.h
+++ b/utils/am_util_multi_boot_private.h
@@ -1,0 +1,178 @@
+//*****************************************************************************
+//
+//! @file am_util_multi_boot_private.h
+//!
+//! @brief Internal definitions/structures shared within multiboot
+//!
+//
+//*****************************************************************************
+
+//*****************************************************************************
+//
+// ${copyright}
+//
+// This is part of revision ${version} of the AmbiqSuite Development Package.
+//
+//*****************************************************************************
+
+#ifndef AM_MULTI_BOOT_PRIVATE_H
+#define AM_MULTI_BOOT_PRIVATE_H
+
+#include "am_mcu_apollo.h"
+#include "am_bsp.h"
+#include "am_util.h"
+// Include config before other bootloader files
+#ifdef AM_MULTIBOOT_CONFIG_FILE
+#include AM_MULTIBOOT_CONFIG_FILE
+#endif
+
+#include "am_util_bootloader.h"
+
+#ifdef MULTIBOOT_SECURE
+#include "am_util_multi_boot_secure.h"
+#endif
+
+//*****************************************************************************
+//
+// I2C Address to use
+//
+//*****************************************************************************
+#ifndef I2C_SLAVE_ADDR
+#define I2C_SLAVE_ADDR                     0x10
+#endif
+
+//*****************************************************************************
+//
+// Run without flag page.
+//
+//*****************************************************************************
+#ifndef USE_FLAG_PAGE
+#define USE_FLAG_PAGE                       0
+#endif
+
+//*****************************************************************************
+//
+// Location of the flag page.
+//
+//*****************************************************************************
+#ifndef FLAG_PAGE_LOCATION
+#define FLAG_PAGE_LOCATION                 0x00004000
+#endif
+
+//*****************************************************************************
+//
+// Max Size of Bootloader.
+//
+//*****************************************************************************
+// The value here must match (at least) with the ROLength restriction imposed at
+// bootloader linker configuration
+#ifndef MAX_BOOTLOADER_SIZE
+#define MAX_BOOTLOADER_SIZE                0x00004000
+#endif
+// The value here must match (at least) with the RWLength restriction imposed at
+// bootloader linker configuration
+#ifndef MAX_SRAM_USED
+#define MAX_SRAM_USED                      0x00004000
+#endif
+
+extern am_util_bootloader_image_t *g_psBootImage;
+
+//*****************************************************************************
+//
+// Safety Checks.
+//
+//*****************************************************************************
+#if USE_FLAG_PAGE == 1
+#if FLAG_PAGE_LOCATION & (AM_HAL_FLASH_PAGE_SIZE - 1)
+#error "Flag Page address not page aligned"
+#endif
+#if FLAG_PAGE_LOCATION < MAX_BOOTLOADER_SIZE
+#error "Flag Page overlaps with Bootloader"
+#endif
+#endif
+
+//*****************************************************************************
+//
+// Default settings.
+//
+//*****************************************************************************
+#ifndef DEFAULT_LINK_ADDRESS
+#define DEFAULT_LINK_ADDRESS                ((uint32_t *) 0x00008000)
+#endif
+// Default override configured as invalid
+#ifndef DEFAULT_OVERRIDE_GPIO
+#define DEFAULT_OVERRIDE_GPIO               (0xFFFFFFFF)
+#endif
+#ifndef DEFAULT_OVERRIDE_POLARITY
+#define DEFAULT_OVERRIDE_POLARITY           AM_BOOTLOADER_OVERRIDE_LOW
+#endif
+
+//*****************************************************************************
+//
+// Boot Loader Version Number
+//
+//*****************************************************************************
+#define AM_BOOTLOADER_VERSION_NUM           0x00000001
+
+//*****************************************************************************
+//
+// Boot messages.
+//
+//*****************************************************************************
+#define AM_BOOTLOADER_ACK                   0x00000000
+#define AM_BOOTLOADER_NAK                   0x00000001
+#define AM_BOOTLOADER_READY                 0x00000002
+#define AM_BOOTLOADER_IMAGE_COMPLETE        0x00000003
+#define AM_BOOTLOADER_BAD_CRC               0x00000004
+#define AM_BOOTLOADER_ERROR                 0x00000005
+#define AM_BOOTLOADER_BL_VERSION            0x00000006
+#define AM_BOOTLOADER_FW_VERSION            0x00000007
+
+//*****************************************************************************
+//
+// Boot Commands.
+//
+//*****************************************************************************
+#define AM_BOOTLOADER_ACK_CMD               0x00000000
+#define AM_BOOTLOADER_NAK_CMD               0x00000001
+#define AM_BOOTLOADER_NEW_IMAGE             0x00000002
+#define AM_BOOTLOADER_NEW_PACKET            0x00000003
+#define AM_BOOTLOADER_RESET                 0x00000004
+#define AM_BOOTLOADER_SET_OVERRIDE_CMD      0x00000005
+#define AM_BOOTLOADER_BL_VERSION_CMD        0x00000006
+#define AM_BOOTLOADER_FW_VERSION_CMD        0x00000007
+#define AM_BOOTLOADER_NEW_ENCRYPTED_IMAGE   0x00000008
+#define AM_BOOTLOADER_RESTART               0x00000009
+
+//*****************************************************************************
+//
+// Globals to keep track of the image write state.
+//
+//*****************************************************************************
+extern uint32_t g_ui32BytesReceived;
+extern uint32_t g_ui32CRC;
+
+//*****************************************************************************
+//
+// Image structure to hold data about the downloaded boot image.
+//
+//*****************************************************************************
+extern am_util_bootloader_image_t g_sImage;
+
+//*****************************************************************************
+//
+// Function declarations.
+//
+//*****************************************************************************
+extern bool
+image_start_packet_read(am_util_bootloader_image_t *psImage, uint32_t *pui32Packet);
+extern void
+image_data_packet_read(uint8_t *pui8Src, uint32_t ui32Size);
+extern void
+program_image(uint32_t bEncrypted);
+
+#ifdef MULTIBOOT_SECURE
+extern void wipe_sram(void);
+#endif
+
+#endif // AM_MULTI_BOOT_PRIVATE_H

--- a/utils/am_util_multi_boot_private.h
+++ b/utils/am_util_multi_boot_private.h
@@ -19,7 +19,6 @@
 #define AM_MULTI_BOOT_PRIVATE_H
 
 #include "am_mcu_apollo.h"
-#include "am_bsp.h"
 #include "am_util.h"
 // Include config before other bootloader files
 #ifdef AM_MULTIBOOT_CONFIG_FILE


### PR DESCRIPTION
The files are not released in the latest SDK4.4.1 and picked from the ambiqsuite/stable fa1eb9ff7a688bf847bce41f3ad2ec6e5b996e6f. Need to replace them once official released.

Also replaces the AmbiqSuite defined SoC macros to
Zephyr ones. And enable the compiling for AMOTA service.
