### PR TITLE
hal: ambiq: apollo510: update HAL drivers and utilities

### DIFF
--- a/mcu/apollo510/hal/am_hal_adc.c
+++ b/mcu/apollo510/hal/am_hal_adc.c
@@ -61,7 +61,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -90,7 +90,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -836,7 +836,7 @@ am_hal_adc_configure_dma(void *pHandle,
     }
 
     //
-    // Enable DMA Halt on Status (DMAERR or DMACPL) by default. This bit is reserved in apollo4
+    // Enable DMA Halt on Status (DMAERR or DMACPL) by default. This bit is reserved in apollo510
     //
 //    ui32Config |= _VAL2FLD(ADC_DMACFG_DMAHONSTAT, ADC_DMACFG_DMAHONSTAT_EN);
 
@@ -981,6 +981,23 @@ am_hal_adc_control(void *pHandle,
                     fCalibration_temp    = priv_temp_trims.flt.fCalibrationTemperature;
                     fCalibration_voltage = priv_temp_trims.flt.fCalibrationVoltage;
                     fCalibration_offset  = priv_temp_trims.flt.fCalibrationOffset;
+
+                    //
+                    // For Apollo510, Vmeas and Voff each require an adjustment.
+                    // They are computed as follows:
+                    //  Voffcorrected = K * (Voff + 1.0F) - 1.0F
+                    //   where K = (1200.F * 1024.0F) / (1023.0F * 1190.0F)
+                    //  Vmeas = (float)ADC_code * 1.20F / 1023.0F
+                    //
+                    // The supplied sample will have to be reverse scaled to the
+                    //  original sample code so it can be operated on with the
+                    //  new factors.
+                    //
+#define fKONST      ((1200.0f * 1024.0f) / (1023.0f * 1190.0f))
+                    uint16_t ADCtemp_code;
+                    fCalibration_offset = fKONST * (fCalibration_offset + 1.0f) - 1.0f;
+                    ADCtemp_code = fVoltage * 1024.0f;  // Assumes 10-bit sample
+                    fVoltage = ADCtemp_code / 1023.0f;
 
                     //
                     // Compute the temperature in K
@@ -1451,6 +1468,15 @@ sample_correction_apply(uint32_t ui32Sample, bool bApplyCorrection)
             // Convert the offset from volts to mv.
             fSampleAdj -= (priv_correction_trims.flt.fADCoffset * 1000.0F);
             fSampleAdj  = fSampleAdj * AM_HAL_ADC_SAMPLE_DIVISORF / AM_HAL_ADC_VREFMVF;
+            // Add overflow and underflow protection
+            if ( fSampleAdj > AM_HAL_ADC_SAMPLE_12BIT_SATF )
+            {
+                fSampleAdj = AM_HAL_ADC_SAMPLE_12BIT_SATF;
+            }
+            if ( fSampleAdj < 0.0F )
+            {
+                fSampleAdj = 0.0F;
+            }
             ui32Sample &= 0xFFF00000;
             ui32Sample |= ((((uint32_t)fSampleAdj) << 6) & AM_HAL_ADC_SAMPLE_MASK_FULL);
         }

--- a/mcu/apollo510/hal/am_hal_adc.h
+++ b/mcu/apollo510/hal/am_hal_adc.h
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #ifndef AM_HAL_ADC_H
@@ -62,13 +62,11 @@
 //! VREF is needed by applications in order to convert samples to voltages,
 //! as well as to do the sample corrections in the HAL functions.
 //!
-//! Important: It is important to use 1.19v, as opposed to 1.20v, as the
-//! reference voltage.
 //! Ambiq recommends using AM_HAL_ADC_VREF to designate Vref in applications.
 //
 // ****************************************************************************
-#define AM_HAL_ADC_VREF         1.19F
-#define AM_HAL_ADC_VREFMV       1190        // Vref specified in millivolts
+#define AM_HAL_ADC_VREF         1.20F
+#define AM_HAL_ADC_VREFMV       1200        // Vref specified in millivolts
 #define AM_HAL_ADC_VREFMVF      (AM_HAL_ADC_VREF * 1000.0F)
 //! @}
 
@@ -87,6 +85,8 @@
 #define AM_HAL_ADC_SAMPLE_DIVISORF      ((float)AM_HAL_ADC_SAMPLE_2N)               // Divisor for 12 bits
 #define AM_HAL_ADC_SAMPLE_MASK          ((AM_HAL_ADC_SAMPLE_2N - 1) << 6)           // Mask for integer portion of the sample
 #define AM_HAL_ADC_SAMPLE_MASK_FULL     (((1 << (AM_HAL_ADC_SAMPLE_BITS + 6)) - 1)) // Mask for the full sample
+#define AM_HAL_ADC_SAMPLE_12BIT_SAT     (AM_HAL_ADC_SAMPLE_2N - 1)                  // ADC saturation value for 12 bits
+#define AM_HAL_ADC_SAMPLE_12BIT_SATF    ((float)(AM_HAL_ADC_SAMPLE_2N - 1))         // ADC saturation value for 12 bits
 //! @}
 
 // ****************************************************************************
@@ -106,10 +106,10 @@
 
 // ****************************************************************************
 //
-//! @brief Default slope (in degK / V) of the Apollo4 temperature sensor.
+//! @brief Default slope (in degK / V) of the Apollo510 temperature sensor.
 //
 // ****************************************************************************
-#define AM_HAL_ADC_TEMPSENSOR_SLOPE     290.0F
+#define AM_HAL_ADC_TEMPSENSOR_SLOPE     302.11F
 
 // ****************************************************************************
 //

--- a/mcu/apollo510/hal/am_hal_audadc.c
+++ b/mcu/apollo510/hal/am_hal_audadc.c
@@ -48,7 +48,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -77,7 +77,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -1225,7 +1225,7 @@ am_hal_audadc_configure_dma(void *pHandle,
     }
 
     //
-    // Enable DMA Halt on Status (DMAERR or DMACPL) by default. This bit is reserved in apollo4
+    // Enable DMA Halt on Status (DMAERR or DMACPL) by default. This bit is reserved in apollo510
     //
 //    ui32Config |= _VAL2FLD(AUDADC_DMACFG_DMAHONSTAT, AUDADC_DMACFG_DMAHONSTAT_EN);
 

--- a/mcu/apollo510/hal/am_hal_global.h
+++ b/mcu/apollo510/hal/am_hal_global.h
@@ -11,7 +11,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -40,7 +40,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #ifndef AM_HAL_GLOBAL_H
@@ -281,7 +281,7 @@ am_hal_triple_read( uint32_t ui32TimerAddr, uint32_t ui32Data[]);
 #elif (defined (__ARMCC_VERSION)) && (__ARMCC_VERSION >= 6000000)
 void
 am_hal_triple_read(uint32_t ui32TimerAddr, uint32_t ui32Data[]);
-#elif defined(__GNUC__)
+#elif defined(__GNUC_STDC_INLINE__)
 __attribute__((naked))
 void
 am_hal_triple_read(uint32_t ui32TimerAddr, uint32_t ui32Data[]);

--- a/mcu/apollo510/hal/am_hal_gpio.c
+++ b/mcu/apollo510/hal/am_hal_gpio.c
@@ -46,7 +46,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -75,7 +75,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -250,7 +250,7 @@ g_ui32CfgDSExt[((AM_HAL_PIN_VIRTUAL_FIRST - 1) + 32) / 32] =
 static const uint32_t
 g_ui32DSpintbl[((AM_HAL_PIN_VIRTUAL_FIRST - 1) + 32) / 32] =
 {
-    0x8FC007E6,
+    0x8FC007E7,
     0xE3F3FFFF,
     0x81FFFFFF,
     0xFFFFFFFF,

--- a/mcu/apollo510/hal/am_hal_gpio.h
+++ b/mcu/apollo510/hal/am_hal_gpio.h
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #ifndef AM_HAL_GPIO_H
@@ -63,6 +63,11 @@ extern "C"
 // Macros
 //
 //*****************************************************************************
+
+//
+// This is added because the HFXTAL need not be 32MHz
+//
+#define AM_HAL_PIN_46_CLKOUT_HFXTAL     2 //AM_HAL_PIN_46_CLKOUT_32M
 
 //*****************************************************************************
 //

--- a/mcu/apollo510/hal/am_hal_i2s.c
+++ b/mcu/apollo510/hal/am_hal_i2s.c
@@ -48,7 +48,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -77,7 +77,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -553,6 +553,10 @@ uint32_t am_hal_i2s_control(void *pHandle, am_hal_i2s_request_e eReq, void *pArg
     AM_HAL_I2S_CHK_HANDLE(pHandle);
 #endif // AM_HAL_DISABLE_API_VALIDATION
 
+    uint32_t ui32ChannelNumbersForMono = 0;
+    uint32_t ui32FramePeriod = 0;
+    am_hal_i2s_data_format_t* pI2SData = NULL;
+    am_hal_i2s_io_signal_t* pIoConfig = NULL;
     switch (eReq)
     {
         case AM_HAL_I2S_REQ_INTSET:
@@ -576,7 +580,6 @@ uint32_t am_hal_i2s_control(void *pHandle, am_hal_i2s_request_e eReq, void *pArg
         case AM_HAL_I2S_REQ_WRITE_TXLOWERLIMIT:
             I2Sn(ui32Module)->TXLOWERLIMIT = *((uint32_t*)pArgs);
             break;
-
         case AM_HAL_I2S_REQ_SET_CH_NUM_FOR_MONO:
             if (pArgs == NULL)
             {
@@ -584,15 +587,15 @@ uint32_t am_hal_i2s_control(void *pHandle, am_hal_i2s_request_e eReq, void *pArg
             }
 
             // Only 1 or 2 channels are allowed for mono mode.
-            uint32_t ui32ChannelNumbersForMono = *((uint32_t*)pArgs);
+            ui32ChannelNumbersForMono = *((uint32_t*)pArgs);
             if ((ui32ChannelNumbersForMono != 1) && (ui32ChannelNumbersForMono != 2))
             {
                 return AM_HAL_STATUS_INVALID_ARG;
             }
 
-            am_hal_i2s_data_format_t* pI2SData = &(pState->sDataFormat);
-            am_hal_i2s_io_signal_t* pIoConfig = &(pState->sIoConfig);
-            uint32_t ui32FramePeriod = ui32ChannelNumbersForMono * ui32I2sWordLength[pI2SData->eChannelLenPhase1];
+            pI2SData = &(pState->sDataFormat);
+            pIoConfig = &(pState->sIoConfig);
+            ui32FramePeriod = ui32ChannelNumbersForMono * ui32I2sWordLength[pI2SData->eChannelLenPhase1];
             if ((pI2SData->ePhase == AM_HAL_I2S_DATA_PHASE_SINGLE) && (pI2SData->ui32ChannelNumbersPhase1 == 1))
             {
                 I2Sn(ui32Module)->I2SIOCFG_b.FPER = ui32FramePeriod - 1;
@@ -612,7 +615,6 @@ uint32_t am_hal_i2s_control(void *pHandle, am_hal_i2s_request_e eReq, void *pArg
             {
                 return AM_HAL_STATUS_INVALID_OPERATION;
             }
-
             break;
 
         case AM_HAL_I2S_REQ_MAX:

--- a/mcu/apollo510/hal/am_hal_info.h
+++ b/mcu/apollo510/hal/am_hal_info.h
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #ifndef AM_HAL_INFO_H
@@ -93,18 +93,24 @@ extern bool am_hal_info0_valid(void);
 
 //*****************************************************************************
 //
-// AM_INFO_FLD2VAL()
-// This macro allows decoding of INFOx register fields, similar
-// to the CMSIS _FLD2VAL macro.
-// Parameters:
-//  info: 0, 1, or C (C must be capitalized)
-//  field: The field of the register.
-//  value: The value of the entire register as read from the INFOx space.
+//! AM_INFO_FLD2VAL_OTP()
+//! AM_INFO_FLD2VAL()
+//! This macro allows decoding of INFOx register fields, similar
+//! to the CMSIS _FLD2VAL macro.
+//! Parameters:
+//!  info: 0, 1, or C (C must be capitalized)
+//!  field: The field of the register.
+//!  value: The value of the entire register as read from the INFOx space.
 //
-// AM_INFO_VAL2FLD() is not provided as the INFOx register definitions already generate these for each register.
+//! AM_INFO_VAL2FLD() is not provided as the INFOx register definitions already
+//!  generate these for each register.
+//
+//! In general, for purposes of extracting fields, it does not matter whether
+//! the 'OTP' or 'MRAM' version is used as the field extractions are the same.
 //
 //*****************************************************************************
-#define AM_INFO_FLD2VAL(info, field, value) (((uint32_t)(value) & AM_REG_INFO ##info## _ ## field ## _Msk) >> AM_REG_INFO ## info ## _ ## field ## _Pos)
+#define AM_INFO_FLD2VAL_OTP(info, field, value) (((uint32_t)(value) & AM_REG_OTP_INFO ##info## _ ## field ## _Msk) >> AM_REG_OTP_INFO ## info ## _ ## field ## _Pos)
+#define AM_INFO_FLD2VAL(info, field, value)     (((uint32_t)(value) & AM_REG_INFO ##info## _ ## field ## _Msk) >> AM_REG_INFO ## info ## _ ## field ## _Pos)
 
 //*****************************************************************************
 //

--- a/mcu/apollo510/hal/am_hal_pwrctrl.c
+++ b/mcu/apollo510/hal/am_hal_pwrctrl.c
@@ -49,7 +49,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -78,7 +78,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_5p1p0beta-2927d425bf of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #include <stdint.h>
@@ -2339,7 +2339,7 @@ am_hal_pwrctrl_low_power_init(void)
     //
     // Power down Crypto.
     //
-    am_hal_pwrctrl_periph_disable(AM_HAL_PWRCTRL_PERIPH_CRYPTO);
+    am_hal_pwrctrl_control(AM_HAL_PWRCTRL_CONTROL_CRYPTO_POWERDOWN, NULL);
 
     //
     // Power down OTP.
@@ -2557,7 +2557,7 @@ am_hal_pwrctrl_control(am_hal_pwrctrl_control_e eControl, void *pArgs)
             }
             break;
 
-            // Use am_hal_pwrctrl_control(AM_HAL_PWRCTRL_CONTROL_CRYPTO_POWERDOWN) if using crypto
+            // Use am_hal_pwrctrl_control(AM_HAL_PWRCTRL_CONTROL_CRYPTO_POWERDOWN, NULL) if using crypto
         case AM_HAL_PWRCTRL_CONTROL_CRYPTO_POWERDOWN:
             {
                 bool        bEnabled;

--- a/mcu/apollo510/hal/am_hal_pwrctrl.h
+++ b/mcu/apollo510/hal/am_hal_pwrctrl.h
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_5p1p0beta-2927d425bf of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -95,14 +95,6 @@ extern "C"
 //*****************************************************************************
 #define NO_TEMPSENSE_IN_DEEPSLEEP                       false
 
-//*****************************************************************************
-//
-//! Option for the TempCo power minimum power.
-//! The tempco algorithm is still being tuned for optimal operation, and hence
-//! it is possible that for certain temperature ranges, it does not yet get the
-//! most optimal settings (might increase power, when compared to without tempco).
-//
-//*****************************************************************************
 //*****************************************************************************
 //
 //! Enable VDDC TempCo. This MACRO only applies to PCM2.0 and PCM1.1 and PCM1.0.

--- a/mcu/apollo510/hal/am_hal_security.c
+++ b/mcu/apollo510/hal/am_hal_security.c
@@ -46,7 +46,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -75,7 +75,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision stable-c286075505 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #include <stdint.h>
@@ -596,7 +596,7 @@ bl_run_main(uint32_t *vtor)
         "   ldr     r3, [r0, #0]\n\t"   // Load the new stack pointer into R1 and the new reset vector into R2.
         "   ldr     r2, [r0, #4]\n\t"
         "   mov     sp, r3\n\t"         // Set the stack pointer for the new image.
-        "   bx      r2\n\t"            // Jump to the new reset vector.
+        "   bx      r2\n\t"             // Jump to the new reset vector.
     );
 }
 #elif defined(__GNUC_STDC_INLINE__)
@@ -612,7 +612,7 @@ bl_run_main(uint32_t *vtor)
         "   ldr     r3, [r0, #0]\n\t"   // Load the new stack pointer into R1 and the new reset vector into R2.
         "   ldr     r2, [r0, #4]\n\t"
         "   mov     sp, r3\n\t"         // Set the stack pointer for the new image.
-        "   bx      r2\n\t"            // Jump to the new reset vector.
+        "   bx      r2\n\t"             // Jump to the new reset vector.
     );
 }
 #elif defined(__IAR_SYSTEMS_ICC__)
@@ -626,7 +626,7 @@ bl_run_main(uint32_t *vtor)
           "    ldr     r3, [r0, #0]\n"   // Load the new stack pointer into R1 and the new reset vector into R2.
           "    ldr     r2, [r0, #4]\n"
           "    mov     sp, r3\n"         // Set the stack pointer for the new image.
-          "    bx      r2\n"            // Jump to the new reset vector.
+          "    bx      r2\n"             // Jump to the new reset vector.
           );
 }
 #else
@@ -686,7 +686,7 @@ am_hal_bootloader_exit(uint32_t *pImage, bool bEnableDebuggerOnExit)
             uint32_t dhcsr = DCB->DSCSR;
 
             //
-            // Halt the core
+            // Halt the core and enable the debugger
             //
             DCB->DSCSR = (uint32_t)(0xA05FUL << 16) | (dhcsr & 0xFFFF) | 0x3;
 

--- a/mcu/apollo510/hal/am_hal_spotmgr.h
+++ b/mcu/apollo510/hal/am_hal_spotmgr.h
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_5p1p0beta-2927d425bf of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #ifndef AM_HAL_SPOTMGR_H
@@ -339,8 +339,8 @@ typedef enum
 //
 typedef struct
 {
-    uint32_t ui32DevPwrSt; // Place holder - may be used in the future
-    uint32_t ui32AudSSPwrSt; // Place holder - may be used in the future
+    uint32_t ui32DevPwrSt;
+    uint32_t ui32AudSSPwrSt;
     uint32_t ui32MemPwrSt; // Place holder - may be used in the future
     uint32_t ui32SsramPwrSt; // Place holder - may be used in the future
     am_hal_spotmgr_tempco_range_e eTempRange;

--- a/mcu/apollo510/hal/am_hal_spotmgr_pcm2_0.c
+++ b/mcu/apollo510/hal/am_hal_spotmgr_pcm2_0.c
@@ -46,7 +46,7 @@
 
 // ****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -75,7 +75,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_5p1p0beta-2927d425bf of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 // ****************************************************************************
 
@@ -472,7 +472,10 @@ spotmgr_buck_deepsleep_state_determine(void)
             {
                 if ((TIMERn(ui32TimerNumber)->CTRL0_b.TMR0EN == TIMER_CTRL0_TMR0EN_EN) &&
                     (TIMER->GLOBEN & (TIMER_GLOBEN_ENB0_EN << ui32TimerNumber))        &&
-                    (((TIMERn(ui32TimerNumber)->CTRL0_b.TMR0CLK >= AM_HAL_TIMER_CLOCK_HFRC_DIV4)            &&
+                    ((
+#if AM_HAL_TIMER_CLOCK_HFRC_DIV4 != 0   // Avoid compiler warning "pointless comparison of unsigned integer with zero"
+                      (TIMERn(ui32TimerNumber)->CTRL0_b.TMR0CLK >= AM_HAL_TIMER_CLOCK_HFRC_DIV4)            &&
+#endif
                       (TIMERn(ui32TimerNumber)->CTRL0_b.TMR0CLK <= AM_HAL_TIMER_CLOCK_HFRC_DIV4K))          ||
                      ((TIMERn(ui32TimerNumber)->CTRL0_b.TMR0CLK >= AM_HAL_TIMER_CLOCK_HFRC2_125MHz_DIV8)    &&
                       (TIMERn(ui32TimerNumber)->CTRL0_b.TMR0CLK <= AM_HAL_TIMER_CLOCK_HFRC2_125MHz_DIV256)) ||

--- a/mcu/apollo510/hal/am_hal_spotmgr_pcm2_1.c
+++ b/mcu/apollo510/hal/am_hal_spotmgr_pcm2_1.c
@@ -45,7 +45,7 @@
 
 // ****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -74,7 +74,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_5p1p0beta-2927d425bf of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 // ****************************************************************************
 
@@ -446,7 +446,10 @@ spotmgr_buck_deepsleep_state_determine(am_hal_spotmgr_power_status_t * psPwrStat
             {
                 if ((TIMERn(ui32TimerNumber)->CTRL0_b.TMR0EN == TIMER_CTRL0_TMR0EN_EN) &&
                     (TIMER->GLOBEN & (TIMER_GLOBEN_ENB0_EN << ui32TimerNumber))        &&
-                    (((TIMERn(ui32TimerNumber)->CTRL0_b.TMR0CLK >= AM_HAL_TIMER_CLOCK_HFRC_DIV4)            &&
+                    ((
+#if AM_HAL_TIMER_CLOCK_HFRC_DIV4 != 0   // Avoid compiler warning "pointless comparison of unsigned integer with zero"
+                      (TIMERn(ui32TimerNumber)->CTRL0_b.TMR0CLK >= AM_HAL_TIMER_CLOCK_HFRC_DIV4)            &&
+#endif
                       (TIMERn(ui32TimerNumber)->CTRL0_b.TMR0CLK <= AM_HAL_TIMER_CLOCK_HFRC_DIV4K))          ||
                      ((TIMERn(ui32TimerNumber)->CTRL0_b.TMR0CLK >= AM_HAL_TIMER_CLOCK_HFRC2_125MHz_DIV8)    &&
                       (TIMERn(ui32TimerNumber)->CTRL0_b.TMR0CLK <= AM_HAL_TIMER_CLOCK_HFRC2_125MHz_DIV256)) ||
@@ -2114,9 +2117,9 @@ am_hal_spotmgr_pcm2_1_init(void)
         ui32Tmp1 = (g_sSpotMgrINFO1regs.sEtrim.E_TRIMCODE_b.L16 + g_sSpotMgrINFO1regs.sEtrim.E_TRIMCODE_b.H16) -
                    (g_sSpotMgrINFO1regs.sLtrim.L_TRIMCODE_b.L16 + g_sSpotMgrINFO1regs.sLtrim.L_TRIMCODE_b.H16);
         ui32Tmp2 = g_sSpotMgrINFO1regs.sPowerStateArray[12].PWRSTATE_b.TVRGFACTTRIM - g_sSpotMgrINFO1regs.sPowerStateArray[13].PWRSTATE_b.TVRGFACTTRIM;
-        ui32Tmp2 = (ui32Tmp2 >= 0) ? (ui32Tmp2) : (0);
+
         f32MvBoost = 218 - 0.5f * ui32Tmp1;
-        ui32CodeBoost = (f32MvBoost > 0.0f) ? (f32MvBoost * ui32Tmp2 / 45 + 0.5f) : (0);
+        ui32CodeBoost = (f32MvBoost > 0.0f) ? (uint32_t)((f32MvBoost * (float)ui32Tmp2) / 45.0f + 0.5f) : 0;
 
         for (uint32_t ps = 0; ps < sizeof(g_sSpotMgrINFO1regs.sPowerStateArray) / sizeof(am_hal_spotmgr_trim_settings_t); ps++)
         {

--- a/mcu/apollo510/hal/am_hal_spotmgr_pcm2_2.c
+++ b/mcu/apollo510/hal/am_hal_spotmgr_pcm2_2.c
@@ -45,7 +45,7 @@
 
 // ****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -74,7 +74,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_5p1p0beta-2927d425bf of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 // ****************************************************************************
 
@@ -221,6 +221,7 @@ typedef uint32_t (*TransitionSequencePtr)(uint32_t, uint32_t, uint32_t, uint32_t
 
 //! Maximum delay for waiting for timer AM_HAL_INTERNAL_TIMER_NUM_A is disabled
 #define TIMER_A_DISABLE_WAIT_IN_US   2500
+
 
 //! VDDCLVACTLOWTONTRIM trim code for power state 0 2 3.
 #define VDDCLVACTLOWTONTRIM_POWER_STATE_0_2_3 7
@@ -1885,7 +1886,10 @@ spotmgr_buck_deepsleep_state_determine(am_hal_spotmgr_power_status_t * psPwrStat
             {
                 if ((TIMERn(ui32TimerNumber)->CTRL0_b.TMR0EN == TIMER_CTRL0_TMR0EN_EN) &&
                     (TIMER->GLOBEN & (TIMER_GLOBEN_ENB0_EN << ui32TimerNumber))        &&
-                    (((TIMERn(ui32TimerNumber)->CTRL0_b.TMR0CLK >= AM_HAL_TIMER_CLOCK_HFRC_DIV4)            &&
+                    ((
+#if AM_HAL_TIMER_CLOCK_HFRC_DIV4 != 0   // Avoid compiler warning "pointless comparison of unsigned integer with zero"
+                      (TIMERn(ui32TimerNumber)->CTRL0_b.TMR0CLK >= AM_HAL_TIMER_CLOCK_HFRC_DIV4)            &&
+#endif
                       (TIMERn(ui32TimerNumber)->CTRL0_b.TMR0CLK <= AM_HAL_TIMER_CLOCK_HFRC_DIV4K))          ||
                      ((TIMERn(ui32TimerNumber)->CTRL0_b.TMR0CLK >= AM_HAL_TIMER_CLOCK_HFRC2_125MHz_DIV8)    &&
                       (TIMERn(ui32TimerNumber)->CTRL0_b.TMR0CLK <= AM_HAL_TIMER_CLOCK_HFRC2_125MHz_DIV256)) ||
@@ -3271,10 +3275,9 @@ am_hal_spotmgr_pcm2_2_init(void)
         ui32Tmp1 = (g_sSpotMgrINFO1regs.sEtrim.E_TRIMCODE_b.L16 + g_sSpotMgrINFO1regs.sEtrim.E_TRIMCODE_b.H16) -
                    (g_sSpotMgrINFO1regs.sLtrim.L_TRIMCODE_b.L16 + g_sSpotMgrINFO1regs.sLtrim.L_TRIMCODE_b.H16);
         ui32Tmp2 = TVRGFACTTRIM2 - TVRGFACTTRIM3;
-        ui32Tmp2 = (ui32Tmp2 >= 0) ? (ui32Tmp2) : (0);
         f32MvBoost = 220 - 0.5f * ui32Tmp1;
-        f32MvBoost = (f32MvBoost > 0.0f) ? (f32MvBoost) : (0);
-        ui32CodeBoost = ((TVRGFACTTRIM3 == 0) && (ui32Tmp2 < 20)) ? (f32MvBoost * 20 / 45 + 0.5f) : (f32MvBoost * ui32Tmp2 / 45 + 0.5f);
+        f32MvBoost = (f32MvBoost > 0.0f) ? f32MvBoost : 0.0f;
+        ui32CodeBoost = ((TVRGFACTTRIM3 == 0) && (ui32Tmp2 < 20)) ? (uint32_t)((f32MvBoost * 20.0f) / 45.0f + 0.5f) : (uint32_t)(f32MvBoost * ui32Tmp2 / 45.0f + 0.5f);
 
         for (uint32_t ps = 0; ps < sizeof(g_sSpotMgrINFO1regs.sPowerStateArray) / sizeof(am_hal_spotmgr_trim_settings_t); ps++)
         {

--- a/mcu/apollo510/hal/am_hal_stimer.c
+++ b/mcu/apollo510/hal/am_hal_stimer.c
@@ -45,11 +45,12 @@
 //! - @b Compare @b Channels: Configure up to 8 compare channels
 //! - @b Capture @b Channels: Set up input capture for external signals
 //! - @b Interrupts: Configure interrupt sources and handlers
+//
 //*****************************************************************************
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -78,7 +79,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -96,8 +97,8 @@ static bool g_bStimerConfigured = false;
 //
 static uint32_t g_ui32LastStimer[8] =
 {
-    0xFFFFFFFE, 0xFFFFFFFE, 0xFFFFFFFE, 0xFFFFFFFE,
-    0xFFFFFFFE, 0xFFFFFFFE, 0xFFFFFFFE, 0xFFFFFFFE
+    0xFFFFFFFD, 0xFFFFFFFD, 0xFFFFFFFD, 0xFFFFFFFD,
+    0xFFFFFFFD, 0xFFFFFFFD, 0xFFFFFFFD, 0xFFFFFFFD
 };
 
 //*****************************************************************************
@@ -237,10 +238,14 @@ am_hal_stimer_is_running(void)
     //
     // Check the STIMER has been configured and is currently counting
     //
-    bRetVal = g_bStimerConfigured &&
-      ((STIMER->STCFG &
-       (STIMER_STCFG_CLKSEL_NOCLK | STIMER_STCFG_FREEZE_THAW | STIMER_STCFG_CLEAR_RUN)) ==
-       (STIMER_STCFG_FREEZE_THAW | STIMER_STCFG_CLEAR_RUN));
+	uint32_t ui32Cfg = STIMER->STCFG;
+
+	bRetVal = g_bStimerConfigured &&
+		((ui32Cfg & STIMER_STCFG_CLKSEL_Msk) !=
+			_VAL2FLD(STIMER_STCFG_CLKSEL, STIMER_STCFG_CLKSEL_NOCLK)) &&
+		((ui32Cfg & (STIMER_STCFG_FREEZE_Msk | STIMER_STCFG_CLEAR_Msk)) ==
+			(_VAL2FLD(STIMER_STCFG_FREEZE, STIMER_STCFG_FREEZE_THAW) |
+			_VAL2FLD(STIMER_STCFG_CLEAR, STIMER_STCFG_CLEAR_RUN)));
 
     AM_CRITICAL_END
 
@@ -387,10 +392,11 @@ am_hal_stimer_check_compare_delta_set(uint32_t ui32CmprInstance)
 
     //
     // We cannot set COMPARE back to back
-    // Need to wait for previous write to complete, which takes 2 cycles
+    // Need to wait for previous write to complete, which takes 3 cycles
     //
-    if ((curTimer != g_ui32LastStimer[ui32CmprInstance]) &&
-        (curTimer != (g_ui32LastStimer[ui32CmprInstance] + 1)))
+        if ((curTimer != g_ui32LastStimer[ui32CmprInstance]) &&
+            (curTimer != (g_ui32LastStimer[ui32CmprInstance] + 1)) &&
+            (curTimer != (g_ui32LastStimer[ui32CmprInstance] + 2)))
     {
         return true;
     }
@@ -408,12 +414,6 @@ am_hal_stimer_check_compare_delta_set(uint32_t ui32CmprInstance)
 uint32_t
 am_hal_stimer_compare_delta_set(uint32_t ui32CmprInstance, uint32_t ui32Delta)
 {
-#ifndef AM_HAL_DISABLE_API_VALIDATION
-    if ( ui32CmprInstance > 7 )
-    {
-        return AM_HAL_STATUS_OUT_OF_RANGE;
-    }
-#endif
     uint32_t curTimer, curTimer0;
     uint32_t ui32Ret = AM_HAL_STATUS_SUCCESS;
 
@@ -422,6 +422,12 @@ am_hal_stimer_compare_delta_set(uint32_t ui32CmprInstance, uint32_t ui32Delta)
     //
     curTimer = curTimer0 = am_hal_stimer_counter_get();
 
+#ifndef AM_HAL_DISABLE_API_VALIDATION
+    if ( ui32CmprInstance > 7 )
+    {
+        return AM_HAL_STATUS_OUT_OF_RANGE;
+    }
+#endif
     //
     //! @note Due to latency in write to COMPARE register to take effect, it is
     //!  possible that the application could get a stale interrupt even after
@@ -432,23 +438,28 @@ am_hal_stimer_compare_delta_set(uint32_t ui32CmprInstance, uint32_t ui32Delta)
 
     do
     {
+        //
         // We cannot set COMPARE back to back
-        // Need to wait for previous write to complete, which takes 2 cycles
+        // Need to wait for previous write to complete, which takes 3 cycles
+        //
         if ((curTimer != g_ui32LastStimer[ui32CmprInstance]) &&
-            (curTimer != (g_ui32LastStimer[ui32CmprInstance] + 1)))
+            (curTimer != (g_ui32LastStimer[ui32CmprInstance] + 1)) &&
+            (curTimer != (g_ui32LastStimer[ui32CmprInstance] + 2)))
         {
             //
             // Start a critical section.
             //
             AM_CRITICAL_BEGIN
-
             curTimer = am_hal_stimer_counter_get();
 
+
+            //
             // Adjust Delta
-            // It takes 2 STIMER clock cycles for writes to COMPARE to be effective
+            // It takes 3 STIMER clock cycles for writes to COMPARE to be effective
             // Also the interrupt itself is delayed by a cycle
             // This effectively means we need to adjust the delta by 3
             // Also adjust for the delay since we entered the function
+            //
             if (ui32Delta > (3 + (curTimer - curTimer0)))
             {
                 ui32Delta -= 3 + (curTimer - curTimer0);
@@ -461,12 +472,10 @@ am_hal_stimer_compare_delta_set(uint32_t ui32CmprInstance, uint32_t ui32Delta)
                 ui32Delta = 1;
                 ui32Ret = AM_HAL_STIMER_DELTA_TOO_SMALL;
             }
-
             //
             // Set the delta
             //
             AM_REGVAL(AM_REG_STIMER_COMPARE(0, ui32CmprInstance)) = ui32Delta;
-
             //
             // Get a snapshot when we set COMPARE
             //

--- a/mcu/apollo510/hal/am_hal_usb.c
+++ b/mcu/apollo510/hal/am_hal_usb.c
@@ -48,7 +48,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -77,7 +77,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -104,9 +104,6 @@
 //
 // #define AM_HAL_USB_CTRL_XFR_AUTO_STATUS_STATE_ACK
 
-#ifdef __ZEPHYR__
-#define AM_HAL_USB_CTRL_XFR_AUTO_STATUS_STATE_ACK
-#endif
 
 //*****************************************************************
 //
@@ -852,6 +849,17 @@ typedef enum
     AM_HAL_USB_EP_XFER_INTERRUPT
 }
 am_hal_usb_ep_xfer_type_e;
+
+//
+//! USB external clock selection
+//
+typedef enum
+{
+    eUSB_R14_NOCHANGE = 0x7F,   // use default
+    eUSB_R14_X40 = 0,           // use for 24Mhz
+    eUSB_R14_X20 = 1,           // use for 12 Mhz
+
+} usbphy_reg14_state_e;
 
 //*****************************************************************************
 //
@@ -1600,7 +1608,6 @@ am_hal_usb_dev_speed_e
 am_hal_get_usb_dev_speed(void *pHandle)
 {
     am_hal_usb_state_t *pState = (am_hal_usb_state_t *)pHandle;
-    USB_Type *pUSB = USBn(pState->ui32Module);
 
 #ifndef AM_HAL_DISABLE_API_VALIDATION
     if (!AM_HAL_USB_CHK_HANDLE(pHandle) )
@@ -1609,14 +1616,7 @@ am_hal_get_usb_dev_speed(void *pHandle)
     }
 #endif
 
-    if(POWER_HSMode(pUSB))
-    {
-        return AM_HAL_USB_SPEED_HIGH;
-    }
-    else
-    {
-        return AM_HAL_USB_SPEED_FULL;
-    }
+    return pState->eDevSpeed;
 }
 
 //*****************************************************************************
@@ -2063,6 +2063,11 @@ am_hal_usb_fifo_unloading_dma1(USB_Type *pUSB, am_hal_usb_state_t *pState, uint8
         {
             am_hal_usb_intr_out_status_clear(pState, ui8EpNum);
             OUTCSRL_OutPktRdy_Clear(pUSB);
+
+#ifdef AM_HAL_USB_REPORT_ZLP
+            am_hal_usb_xfer_complete(pState, pXfer, ui8EpNum, ui32OutCnt, USB_XFER_DONE, NULL);
+            return AM_HAL_STATUS_SUCCESS;
+#endif // AM_HAL_USB_REPORT_ZLP
         }
         else if (ui32OutCnt < OUTMAXP_MaxPayload(pUSB))
         {
@@ -2070,8 +2075,16 @@ am_hal_usb_fifo_unloading_dma1(USB_Type *pUSB, am_hal_usb_state_t *pState, uint8
             am_hal_usb_fifo_unloading(pUSB, ui8EpNum, pucBuf, ui32LenUnload);
             am_hal_usb_intr_out_status_clear(pState, ui8EpNum);
             OUTCSRL_OutPktRdy_Clear(pUSB);
+#ifdef AM_HAL_USB_REPORT_ZLP
             am_hal_usb_xfer_complete(pState, pXfer, ui8EpNum, ui32LenUnload, USB_XFER_DONE, NULL);
             return AM_HAL_STATUS_SUCCESS;
+#else
+            if (ui32LenUnload != 0)
+            {
+                am_hal_usb_xfer_complete(pState, pXfer, ui8EpNum, ui32LenUnload, USB_XFER_DONE, NULL);
+                return AM_HAL_STATUS_SUCCESS;
+            }
+#endif // AM_HAL_USB_REPORT_ZLP
         }
     }
 
@@ -2269,6 +2282,8 @@ am_hal_usb_dma_loading_fifo(USB_Type *pUSB, uint8_t ui8EpNum, uint8_t *pucBuf, u
         .eDir           = AM_HAL_USB_IN_DIR
     };
 
+    INCSRU_AutoSet_Set(pUSB);
+
     AM_HAL_USB_ENTER_CRITICAL;
 
     if ( g_bUSBDMA0Busy )
@@ -2454,40 +2469,6 @@ am_hal_usb_ep0_state_reset(am_hal_usb_state_t *pState)
 {
     pState->eEP0State = AM_HAL_USB_EP0_STATE_IDLE;
     am_hal_usb_xfer_reset(&pState->ep0_xfer);
-}
-
-
-void am_hal_usb_ep_state_reset(void *pHandle, uint8_t ui8EpAddr)
-{
-#ifndef AM_HAL_DISABLE_API_VALIDATION
-    if (!AM_HAL_USB_CHK_HANDLE(pHandle) )
-    {
-        return AM_HAL_STATUS_INVALID_HANDLE;
-    }
-    if (AM_HAL_USB_CHK_EP_NUM(ui8EpAddr))
-    {
-        return AM_HAL_STATUS_INVALID_ARG;
-    }
-#endif
-    am_hal_usb_state_t *pState;
-    am_hal_usb_ep_xfer_t *pXfer;
-    uint8_t ui8EpNum, ui8EpDir;
-
-    pState = (am_hal_usb_state_t *)pHandle;
-    ui8EpNum = am_hal_usb_ep_number(ui8EpAddr);
-    ui8EpDir = am_hal_usb_ep_dir(ui8EpAddr);
-
-    if (ui8EpNum == 0)
-    {
-        pState->eEP0State = AM_HAL_USB_EP0_STATE_IDLE;
-        am_hal_usb_xfer_reset(&pState->ep0_xfer);
-    }
-    else
-    {
-        pXfer = &pState->ep_xfers[ui8EpNum - 1][ui8EpDir];
-        am_hal_usb_xfer_reset(pXfer);
-    }
-
 }
 
 //*****************************************************************************
@@ -4034,7 +4015,7 @@ am_hal_usb_in_ep_handling(am_hal_usb_state_t *pState, USB_Type *pUSB, uint8_t ui
     }
 
     // In endpoint FIFO is empty
-    if ((INCSRL_FIFONotEmpty(pUSB) == 0) && pXfer->flags.busy)
+    if ((INTRINE_Get(pUSB) & (0x1 << ui8EpNum)) && (INCSRL_FIFONotEmpty(pUSB) == 0) && pXfer->flags.busy)
     {
         // Packet has been sent out
         if (pXfer->remaining == 0x0)
@@ -4326,15 +4307,35 @@ am_hal_usb_out_ep_dma1_handling(am_hal_usb_state_t *pState, USB_Type *pUSB, uint
                 ui32XferLen = ui32AdmaTarAddr - (uint32_t)pXfer->buf + count;
                 am_hal_usb_fifo_unloading(pUSB, ui8EpNum, (uint8_t *)ui32AdmaTarAddr, count);
                 INTROUTE_Disable(pUSB, 0x1 << ui8EpNum);
-                am_hal_usb_xfer_complete(pState, pXfer, ui8EpNum, ui32XferLen, USB_XFER_DONE, NULL);
-                OUTCSRL_OutPktRdy_Clear(pUSB);
+#ifdef AM_HAL_USB_REPORT_ZLP
+                if ((count != 0) || (ui32XferLen == 0))
+                {
+                    am_hal_usb_xfer_complete(pState, pXfer, ui8EpNum, ui32XferLen, USB_XFER_DONE, NULL);
+                    OUTCSRL_OutPktRdy_Clear(pUSB);
+                }
+#else
+                if (ui32XferLen != 0)
+                {
+                    am_hal_usb_xfer_complete(pState, pXfer, ui8EpNum, ui32XferLen, USB_XFER_DONE, NULL);
+                }
+                else
+                {
+                    // Re-enable ADMA which was disabled above and clear
+                    // `OutPktRdy` so the hardware can continue receiving
+                    // the next packet.
+                    pUSB->ADMAEN |= (1 << (ui8EpNum + 4));
+                    OUTCSRL_OutPktRdy_Clear(pUSB);
+                }
+#endif // AM_HAL_USB_REPORT_ZLP
                 return;
             }
+#ifndef AM_HAL_USB_REPORT_ZLP
             else if (count == 0)
             {
                 OUTCSRL_OutPktRdy_Clear(pUSB);
-                return;
             }
+#endif // AM_HAL_USB_REPORT_ZLP
+            return;
         }
 
     }
@@ -4403,8 +4404,14 @@ am_hal_usb_out_ep_dma1_adma_handling(am_hal_usb_state_t *pState, USB_Type *pUSB,
         else
         {
             INTROUTE_Disable(pUSB, 0x1 << ui8EpNum);
+#ifdef AM_HAL_USB_REPORT_ZLP
             am_hal_usb_xfer_complete(pState, pXfer, ui8EpNum, ui32XferLen, USB_XFER_DONE, NULL);
-
+#else
+            if (ui32XferLen != 0)
+            {
+                am_hal_usb_xfer_complete(pState, pXfer, ui8EpNum, ui32XferLen, USB_XFER_DONE, NULL);
+            }
+#endif // AM_HAL_USB_REPORT_ZLP
         }
         return;
     }
@@ -4412,13 +4419,13 @@ am_hal_usb_out_ep_dma1_adma_handling(am_hal_usb_state_t *pState, USB_Type *pUSB,
 
 //*****************************************************************************
 //
-// Auto generate clock source and divide ratio if it is not defined by user.
+// Auto configure clock source and divide ratio if it is not defined by user.
 //
 //*****************************************************************************
 static inline void
 am_hal_usb_auto_gen_clk_source(void *pHandle, am_hal_usb_dev_speed_e eSpeed, am_hal_usb_phyclksrc_e *eClkSrc)
 {
-    am_hal_usb_state_t *pState = (am_hal_usb_state_t *) pHandle;
+    usbphy_reg14_state_e reg14State = eUSB_R14_X40;
 
     if (eSpeed == AM_HAL_USB_SPEED_FULL)
     {
@@ -4445,10 +4452,17 @@ am_hal_usb_auto_gen_clk_source(void *pHandle, am_hal_usb_dev_speed_e eSpeed, am_
         {
             *eClkSrc = AM_HAL_USB_PHYCLKSRC_EXTREFCLK;
         }
+        else if (board.ui32ExtRefClkFreq == 12000000)
+        {
+            *eClkSrc = AM_HAL_USB_PHYCLKSRC_EXTREFCLK;
+            reg14State = eUSB_R14_X20;
+        }
         else
         {
             *eClkSrc = AM_HAL_USB_PHYCLKSRC_PLL;
         }
+
+        USBPHY->REG14_b.BF55 = reg14State;
     }
 }
 
@@ -4672,8 +4686,17 @@ am_hal_usb_interrupt_service(void *pHandle,
         if ( pUSB->DMACTRL_b.DMADIR == AM_HAL_USB_IN_DIR )
         {
             // Select the endpoint by index register
-            EP_INDEX_Set(pUSB, pUSB->DMACTRL_b.DMAEP);
-            INCSRL_InPktRdy_Set(pUSB);
+            uint8_t ui8EpNum = pUSB->DMACTRL_b.DMAEP;
+            EP_INDEX_Set(pUSB, ui8EpNum);
+
+            am_hal_usb_ep_xfer_t* pXfer = &pState->ep_xfers[ui8EpNum - 1][AM_HAL_USB_EP_DIR_IN];
+            uint16_t maxpacket = pState->epin_maxpackets[ui8EpNum - 1];
+
+            if (pXfer->len < maxpacket && pXfer->len > 0)
+            {
+                INCSRL_InPktRdy_Set(pUSB);
+            }
+
             INTRINE_Enable(pUSB, 0x1 << pUSB->DMACTRL_b.DMAEP);
         }
         else

--- a/mcu/apollo510/hal/am_hal_usb.h
+++ b/mcu/apollo510/hal/am_hal_usb.h
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -529,7 +529,7 @@ extern uint32_t am_hal_usb_disable_sof_intr(void *pHandle);
 //! @brief Macro definitions for the USB hardware information.
 //!
 //! These macros correspond to the definitions in the datasheet of
-//! apollo4 USB peripheral.
+//! apollo510 USB peripheral.
 //! They may be used with the \e am_hal_usb_get_hw_infor function.
 //!
 //
@@ -1086,17 +1086,6 @@ extern uint32_t am_hal_usb_set_xfer_mode(void *pHandle, am_hal_usb_xfer_mode_e e
 //
 //*****************************************************************************
 extern uint32_t am_hal_usb_enable_ep_double_buffer(void *pHandle, uint8_t epnum, am_hal_usb_xfer_dir_e dir, bool enable);
-
-//*****************************************************************************
-//
-//! @brief Reset USB endpoint state
-//!
-//! @param pHandle - the handle of initialized USB instance
-//! @param ui8EpAddr - USB endpoint address for state reset
-//!
-//
-//*****************************************************************************
-extern void am_hal_usb_ep_state_reset(void *pHandle, uint8_t ui8EpAddr);
 
 #ifdef __cplusplus
 }

--- a/mcu/apollo510/hal/mcu/am_hal_bootrom_helper.h
+++ b/mcu/apollo510/hal/mcu/am_hal_bootrom_helper.h
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #ifndef AM_HAL_BOOTROM_HELPER_H
@@ -65,7 +65,7 @@ extern "C"
 //
 //! Structure of pointers to helper functions invoking flash operations.
 //
-//! The functions we are pointing to here are in the Apollo 4
+//! The functions we are pointing to here are in the Apollo 510
 //! integrated BOOTROM.
 //
 //*****************************************************************************

--- a/mcu/apollo510/hal/mcu/am_hal_card.h
+++ b/mcu/apollo510/hal/mcu/am_hal_card.h
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #ifndef AM_HAL_CARD_H
@@ -487,7 +487,7 @@ extern "C"
 #define MMC_HS200    200000000
 
 //
-// apollo4 SDHC speed limitation settings
+// Apollo510 SDHC speed limitation settings
 //
 #define MMC_HS200_MAX_SPEED_LIMIT   96000000
 #define MMC_HS_MAX_SPEED_LIMIT      48000000
@@ -527,7 +527,7 @@ static inline uint32_t am_hal_unstuff_bits(uint32_t *resp, uint32_t start, uint3
 
 static inline uint32_t am_hal_unstuff_bytes(uint32_t *ext_csd, uint32_t start, uint32_t size)
 {
-    uint32_t i;
+    int i;
     const uint32_t __size = size;
     uint32_t __res = 0x0;
     const uint8_t *__p = (const uint8_t *)ext_csd;

--- a/mcu/apollo510/hal/mcu/am_hal_dsi.c
+++ b/mcu/apollo510/hal/mcu/am_hal_dsi.c
@@ -47,7 +47,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -76,7 +76,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -155,7 +155,7 @@ typedef struct
     // This structure members are valid or not.
     //
     bool                                    bisValid;
-}am_hal_dsi_state_t;
+} am_hal_dsi_state_t;
 
 //*****************************************************************************
 //
@@ -398,23 +398,22 @@ am_hal_dsi_timing(uint32_t ui32FreqTrim)
 
 //*****************************************************************************
 //
-// Initialize the DSI
+// Initialize the DSI for Command mode or video mode.
 //
 //*****************************************************************************
 uint32_t
-am_hal_dsi_para_config(uint8_t ui8LanesNum, uint8_t ui8DBIBusWidth, uint32_t ui32FreqTrim, bool bSendUlpsPattern)
+am_hal_dsi_config(am_hal_dsi_config_t *pDSIConfig)
 {
-
     //
     // ui32DSIFuncPrg_REG (DATA_WIDTH, RESERVED, FMT_VIDEO, CH_NO_CM, CH_NO_VM, DATA_LANE_CNT)
     //                     [15:13]     [12:10]   [9:7]      [6:5]     [4:3]     [2:0]
     //
-    uint32_t ui32DSIFuncPrg = 0;
+    uint32_t ui32DSIFuncPrg = 0, ui32DSICLKFreq = 0, ui32PixelFormat = 0, ui32VideoMode = 0;
 
     //
     // check number of lanes parameters
     //
-    switch (ui8LanesNum)
+    switch (pDSIConfig->ui8LanesNum)
     {
         case DSI_DSIFUNCPRG_DATALANES_DATAL1:
             //
@@ -438,25 +437,64 @@ am_hal_dsi_para_config(uint8_t ui8LanesNum, uint8_t ui8DBIBusWidth, uint32_t ui3
     }
 
     //
+    // virtual channel 0 for video mode
+    //
+    ui32DSIFuncPrg |= _VAL2FLD(DSI_DSIFUNCPRG_CHNUMVM, DSI_DSIFUNCPRG_CHNUMVM_VVCH0);
+
+    //
+    // Virtual channel 0 for command mode
+    //
+    ui32DSIFuncPrg |= _VAL2FLD(DSI_DSIFUNCPRG_CHNUMCMODE, DSI_DSIFUNCPRG_CHNUMCMODE_VCCH0);
+
+    //
+    // Supported format in video mode
+    //
+    switch (pDSIConfig->eFormat)
+    {
+        case DSI_FORMAT_RGB565:
+          ui32DSIFuncPrg |= _VAL2FLD(DSI_DSIFUNCPRG_SUPCOLVIDMODE, DSI_DSIFUNCPRG_SUPCOLVIDMODE_FMTVMODE1);
+          ui32PixelFormat = 16;
+          break;
+
+        case DSI_FORMAT_RGB666:
+          ui32DSIFuncPrg |= _VAL2FLD(DSI_DSIFUNCPRG_SUPCOLVIDMODE, DSI_DSIFUNCPRG_SUPCOLVIDMODE_FMTVMODE2);
+          ui32PixelFormat = 18;
+          break;
+
+        case DSI_FORMAT_RGB666_LOOSELY:
+          ui32DSIFuncPrg |= _VAL2FLD(DSI_DSIFUNCPRG_SUPCOLVIDMODE, DSI_DSIFUNCPRG_SUPCOLVIDMODE_FMTVMODE3); //RGB666 loosely packed format.
+          ui32PixelFormat = 24;
+          break;
+
+        case DSI_FORMAT_RGB888:
+          ui32DSIFuncPrg |= _VAL2FLD(DSI_DSIFUNCPRG_SUPCOLVIDMODE, DSI_DSIFUNCPRG_SUPCOLVIDMODE_FMTVMODE4);
+          ui32PixelFormat = 24;
+          break;
+
+        default:
+          break;
+    }
+
+    //
     // check DBI bus width parameter
     //
-    switch (ui8DBIBusWidth)
+    switch (pDSIConfig->eDBIBusWidth)
     {
-        case 8:
+        case AM_HAL_DSI_DBI_WIDTH_8:
             //
             // The 8bit Interface of DBI-Type B output formats
             //
             ui32DSIFuncPrg |= _VAL2FLD(DSI_DSIFUNCPRG_REGNAME, DSI_DSIFUNCPRG_REGNAME_8BIT);
         break;
 
-        case 9:
+        case AM_HAL_DSI_DBI_WIDTH_9:
             //
             // The 9bit Interface of DBI-Type B output formats
             //
             ui32DSIFuncPrg |= _VAL2FLD(DSI_DSIFUNCPRG_REGNAME, DSI_DSIFUNCPRG_REGNAME_9BIT);
         break;
 
-        case 16:
+        case AM_HAL_DSI_DBI_WIDTH_16:
             //
             // There are two options for 16 bit interface of DBI-Type B output formats. We use option 1 as the default.
             //
@@ -492,12 +530,12 @@ am_hal_dsi_para_config(uint8_t ui8LanesNum, uint8_t ui8DBIBusWidth, uint32_t ui3
     //
     // write into TURN AROUND TIMEOUT REGISTER
     //
-    DSI->TURNARNDTO = _VAL2FLD(DSI_TURNARNDTO_TIMOUT, 0x1F);
+    DSI->TURNARNDTO = _VAL2FLD(DSI_TURNARNDTO_TIMOUT, 0x3F);
 
     //
     // write into DEVICE RESET TIMER REGISTER
     //
-    DSI->DEVICERESETTIMER = _VAL2FLD(DSI_DEVICERESETTIMER_TIMOUT, 0xFF);
+    DSI->DEVICERESETTIMER = _VAL2FLD(DSI_DEVICERESETTIMER_TIMOUT, 0xFFFF);
 
     //
     // write into HIGH TO LOW SWITCH COUNT REGISTER
@@ -505,21 +543,115 @@ am_hal_dsi_para_config(uint8_t ui8LanesNum, uint8_t ui8DBIBusWidth, uint32_t ui3
     DSI->DATALANEHILOSWCNT = _VAL2FLD(DSI_DATALANEHILOSWCNT_DATALHLSWCNT, 0xFFFF);
     DSI->INITCNT = _VAL2FLD(DSI_INITCNT_MSTR, 0x7d0);
 
+    //
+    // check video mode format
+    //
+    switch (pDSIConfig->eMode)
+    {
+        case VIDEO_MODE_NON_BURST_PULSE:
+          DSI->VIDEOMODEFMT = _VAL2FLD(DSI_VIDEOMODEFMT_VIDEMDFMT, DSI_VIDEOMODEFMT_VIDEMDFMT_NONBURSTPULSE);
+          ui32VideoMode = 1;
+          break;
+
+        case VIDEO_MODE_NON_BURST_EVENTS:
+          DSI->VIDEOMODEFMT = _VAL2FLD(DSI_VIDEOMODEFMT_VIDEMDFMT, DSI_VIDEOMODEFMT_VIDEMDFMT_NONBURSTEVENTS);
+          ui32VideoMode = 1;
+          break;
+
+        case VIDEO_MODE_BURST:
+          DSI->VIDEOMODEFMT = _VAL2FLD(DSI_VIDEOMODEFMT_VIDEMDFMT, DSI_VIDEOMODEFMT_VIDEMDFMT_BURST);
+          ui32VideoMode = 2;
+          break;
+
+        default:
+          break;
+    }
+
+    if (fabs(pDSIConfig->fPCLKFreq) > 0.01)
+    {
+        //
+        // Calculate frequency of the txbyteclkhs
+        //
+        float fRatio = (float)ui32PixelFormat * ui32VideoMode / (2 * pDSIConfig->ui8LanesNum) / 4;
+        //
+        // DPI Resolution
+        //
+        DSI->DPIRESOLUTION = _VAL2FLD(DSI_DPIRESOLUTION_DPIRESOLUTION, pDSIConfig->ui32VACT << 16 | pDSIConfig->ui32HACT);
+
+        DSI->HSYNCCNT = _VAL2FLD(DSI_HSYNCCNT_HORZCNT, pDSIConfig->ui32HSA * fRatio);
+        DSI->HORIZBKPORCHCNT = _VAL2FLD(DSI_HORIZBKPORCHCNT_HORZBKPCNT, pDSIConfig->ui32HBP * fRatio);
+        DSI->HORIZFPORCHCNT = _VAL2FLD(DSI_HORIZFPORCHCNT_HORZFTPCNT, pDSIConfig->ui32HFP * fRatio);
+        DSI->HORZACTIVEAREACNT = _VAL2FLD(DSI_HORZACTIVEAREACNT_HORACTCNT, pDSIConfig->ui32HACT * fRatio);
+
+        DSI->VSYNCCNT = _VAL2FLD(DSI_VSYNCCNT_VSC, pDSIConfig->ui32VSA);
+        DSI->VERTBKPORCHCNT = _VAL2FLD(DSI_VERTBKPORCHCNT_VBPSC, pDSIConfig->ui32VBP);
+        DSI->VERTFPORCHCNT = _VAL2FLD(DSI_VERTFPORCHCNT_VFPSC, pDSIConfig->ui32VFP);
+
+        //
+        // Calculate DSI clock frequency.
+        //
+        fRatio *= pDSIConfig->fPCLKFreq * 4;
+
+        if (CLKGEN->DISPCLKCTRL_b.PLLCLKSEL == CLKGEN_DISPCLKCTRL_PLLCLKSEL_HFRC_12MHz)
+        {
+            //
+            // Check whether the DSI frequency can be divided by the PLL reference frequency or not.
+            //
+            if ( fabs(fRatio / 12 - (uint32_t)fRatio / 12) > 0.01 )
+            {
+                return AM_HAL_STATUS_INVALID_ARG;
+            }
+
+            ui32DSICLKFreq = (uint32_t)fRatio;
+            //
+            // Check whether the DSI frequency exceeds the limit.
+            //
+            if (ui32DSICLKFreq > 384)
+            {
+                return AM_HAL_STATUS_OUT_OF_RANGE;
+            }
+            //
+            // Convert the DSI frequency to the trim value used by IP.
+            //
+            if (ui32DSICLKFreq / 12 % 2)
+            {
+                pDSIConfig->eFreqTrim = (am_hal_dsi_freq_trim_e)(ui32DSICLKFreq / 24 + 0x40);
+            }
+            else
+            {
+                pDSIConfig->eFreqTrim = (am_hal_dsi_freq_trim_e)(ui32DSICLKFreq / 24);
+            }
+        }
+        else
+        {
+            //
+            // The software only supports HFRC12 until now.
+            //
+            return AM_HAL_STATUS_INVALID_ARG;
+        }
+    }
+
+    DSI->POLARITY = _VAL2FLD(DSI_POLARITY_PBITS, 0);
+    DSI->ERRORAUTORCOV = 0;
+    DSI->DATALANEPOLSWAP = _VAL2FLD(DSI_DATALANEPOLSWAP_DATALNPOLSWAP, 0);
+
     DSI->CLKEOT = _VAL2FLD(DSI_CLKEOT_CLOCK, 1);
     DSI->CLKEOT |= _VAL2FLD(DSI_CLKEOT_EOT, 1);
-    am_hal_dsi_timing(ui32FreqTrim);
+    DSI->CLKEOT |= _VAL2FLD(DSI_CLKEOT_BTA, 0x1);
+
+    am_hal_dsi_timing((uint32_t)pDSIConfig->eFreqTrim);
     DSI->AFETRIM2 = _VAL2FLD(DSI_AFETRIM2_AFETRIM2, 0x10000000);
-    if (ui8LanesNum == 1)
+    if (pDSIConfig->ui8LanesNum == 1)
     {
         DSI->AFETRIM2 |= _VAL2FLD(DSI_AFETRIM2_AFETRIM2, 0x00480000); // trim_2<22> and trim_2<19> need to be set for DSI TX in 1-lane configuration.
     }
-    else if (ui8LanesNum == 2)
+    else if (pDSIConfig->ui8LanesNum == 2)
     {
         DSI->AFETRIM2 |= _VAL2FLD(DSI_AFETRIM2_AFETRIM2, 0x00400000); // clear power down bit for Data lane 1 to support DSI TX in 2lanes configuration.
     }
     DSI->AFETRIM1 |= _VAL2FLD(DSI_AFETRIM1_AFETRIM1, 0x00002000); // trim_1<13> needs to be set
 
-    if (bSendUlpsPattern)
+    if (pDSIConfig->bSendUlpsPattern)
     {
         DSI->AFETRIM3 |= _VAL2FLD(DSI_AFETRIM3_AFETRIM3, 0x00030000);
     }
@@ -558,7 +690,7 @@ am_hal_dsi_para_config(uint8_t ui8LanesNum, uint8_t ui8DBIBusWidth, uint32_t ui3
         DSI->INTRSTAT_b.LOWC = 1;
     }
 
-    if (bSendUlpsPattern)
+    if (pDSIConfig->bSendUlpsPattern)
     {
         //
         // ULPS Exit sequence
@@ -569,6 +701,22 @@ am_hal_dsi_para_config(uint8_t ui8LanesNum, uint8_t ui8DBIBusWidth, uint32_t ui3
     // Return the status.
     //
     return AM_HAL_STATUS_SUCCESS;
+
+}
+//*****************************************************************************
+//
+// Initialize the DSI
+//
+//*****************************************************************************
+uint32_t
+am_hal_dsi_para_config(uint8_t ui8LanesNum, uint8_t ui8DBIBusWidth, uint32_t ui32FreqTrim, bool bSendUlpsPattern)
+{
+    am_hal_dsi_config_t config = {0};
+    config.ui8LanesNum = ui8LanesNum;
+    config.eDBIBusWidth = (am_hal_dsi_dbi_width_e)ui8DBIBusWidth;
+    config.eFreqTrim = (am_hal_dsi_freq_trim_e)ui32FreqTrim;
+    config.bSendUlpsPattern = bSendUlpsPattern;
+    return am_hal_dsi_config(&config);
 }
 
 //*****************************************************************************
@@ -590,7 +738,7 @@ am_hal_dsi_init(void)
         external_vdd18_callback(true);
     }
 
-    am_hal_clkgen_control(AM_HAL_CLKGEN_CONTROL_DISPCLKSEL_HFRC96, NULL);
+    am_hal_clkgen_control(AM_HAL_CLKGEN_CONTROL_DISPCLKSEL_HFRC192, NULL);
     am_hal_clkgen_control(AM_HAL_CLKGEN_CONTROL_DBICLKDIV2EN_DISABLE, NULL);
     am_hal_clkgen_control(AM_HAL_CLKGEN_CONTROL_DBICLKSEL_DBIB_CLK, NULL);
     am_hal_clkgen_control(AM_HAL_CLKGEN_CONTROL_DCCLK_ENABLE, NULL);
@@ -853,7 +1001,14 @@ uint32_t
 am_hal_dsi_power_control(am_hal_sysctrl_power_state_e ePowerState,
                          bool bRetainState)
 {
-    static am_hal_dsi_state_t sDSIState = {0};
+    static am_hal_dsi_state_t sDSIState =
+    {
+        .eTrim    = (am_hal_dsi_freq_trim_e) 0,
+        .eWidth   = (am_hal_dsi_dbi_width_e) 0,
+        .ui8Lanes = 0,
+        .bisValid = false,
+    };
+
     uint32_t ui32Status = AM_HAL_STATUS_SUCCESS;
     bool bStatus;
     am_hal_pwrctrl_periph_enabled(AM_HAL_PWRCTRL_PERIPH_DISPPHY, &bStatus);

--- a/mcu/apollo510/hal/mcu/am_hal_dsi.h
+++ b/mcu/apollo510/hal/mcu/am_hal_dsi.h
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -154,7 +154,8 @@ typedef enum
 typedef enum
 {
     AM_HAL_DSI_DBI_WIDTH_8  = 8,
-    AM_HAL_DSI_DBI_WIDTH_16 = 16,
+    AM_HAL_DSI_DBI_WIDTH_9  = 9,
+    AM_HAL_DSI_DBI_WIDTH_16 = 16
 } am_hal_dsi_dbi_width_e;
 
 //*****************************************************************************
@@ -178,6 +179,53 @@ typedef enum
     LP_MODE = 0,
     HS_MODE
 } am_hal_dsi_speed_e;
+
+//*****************************************************************************
+//
+//! DSI Command mode and video mode structure.
+//
+//*****************************************************************************
+typedef enum
+{
+    DSI_FORMAT_UNSUPPORTED = 0,
+    DSI_FORMAT_RGB565,
+    DSI_FORMAT_RGB666,
+    DSI_FORMAT_RGB666_LOOSELY,
+    DSI_FORMAT_RGB888
+} am_hal_dsi_color_format_e;
+
+typedef enum
+{
+    VIDEO_MODE_RESERVED = 0,
+    VIDEO_MODE_NON_BURST_PULSE,
+    VIDEO_MODE_NON_BURST_EVENTS,
+    VIDEO_MODE_BURST
+} am_hal_dsi_video_mode_e;
+
+typedef struct
+{
+    uint8_t                             ui8LanesNum;
+    am_hal_dsi_dbi_width_e              eDBIBusWidth;       //For command mode
+    am_hal_dsi_freq_trim_e              eFreqTrim;
+    bool                                bSendUlpsPattern;
+    //
+    // Below parameters are mandatory for video mode not for command mode
+    //
+    am_hal_dsi_color_format_e           eFormat;            //For video mode
+    am_hal_dsi_video_mode_e             eMode;              //For video mode
+    struct
+    {
+        uint32_t                        ui32HACT;           //Active pixels per line
+        uint32_t                        ui32HSA;            //Horizontal sync active
+        uint32_t                        ui32HBP;            //Horizontal back porch
+        uint32_t                        ui32HFP;            //Horizontal front porch
+        uint32_t                        ui32VACT;           //Active lines per frame
+        uint32_t                        ui32VSA;            //Vertial sync active
+        uint32_t                        ui32VBP;            //Vertial back porch
+        uint32_t                        ui32VFP;            //Vertial front porch
+        float                           fPCLKFreq;          //For video mode
+    };
+} am_hal_dsi_config_t;
 
 //*****************************************************************************
 //
@@ -234,12 +282,27 @@ extern uint32_t am_hal_dsi_register_ulps_exit_delay_callback(const am_hal_dsi_de
 //
 //! @brief DSI configuration
 //!
+//! @param pDSIConfig          - pointer to support the DSI video & command mode.
+//!
+//! This function is defined to replace previously function am_hal_dsi_para_config()
+//! to support both DSI command mode and video mode.
+//!
+//! @return AM_HAL_STATUS_SUCCESS
+//
+//*****************************************************************************
+extern uint32_t am_hal_dsi_config(am_hal_dsi_config_t *pDSIConfig);
+
+//*****************************************************************************
+//
+//! @brief DSI configuration
+//!
 //! @param ui8LanesNum          - Number of lanes.
 //! @param ui8DBIBusWidth       - Width of DBI bus.
 //! @param ui32FreqTrim         - DPHY output frequency trim.
 //! @param bSendUlpsPattern     - Send ULPS entry/exit pattern or not.
 //!
-//! This function should be called after DSI power is enabled.
+//! This function should be called after DSI power is enabled. it could not
+//! support the DSI video mode.
 //!
 //! @return AM_HAL_STATUS_SUCCESS
 //

--- a/mcu/apollo510/hal/mcu/am_hal_itm.c
+++ b/mcu/apollo510/hal/mcu/am_hal_itm.c
@@ -47,7 +47,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -76,7 +76,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -196,7 +196,7 @@ am_hal_itm_disable(void)
     //
     ui32Status = am_hal_delay_us_status_change(1000,
                                                (uint32_t)&ITM->TCR,
-                                               (ITM_TCR_ITMENA_Msk & ITM_TCR_BUSY_Msk),
+                                               (ITM_TCR_ITMENA_Msk | ITM_TCR_BUSY_Msk),
                                                0 );
     if ( ui32Status != AM_HAL_STATUS_SUCCESS )
     {

--- a/mcu/apollo510/hal/mcu/am_hal_mcu_interrupt.h
+++ b/mcu/apollo510/hal/mcu/am_hal_mcu_interrupt.h
@@ -14,7 +14,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -43,7 +43,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #ifndef AM_HAL_MCU_INTERRUPT_H
@@ -62,9 +62,6 @@ extern "C"
 #define AM_HAL_INTERRUPT_MAX                (MAX_IRQn - 1)
 
 //
-//! For Apollo4 RevB, a workaround requires masking all interrupts.
-//! This is accomplished by setting a priority of 0, but assumes
-//! any other IRQs have a lower priority (>0).
 //! This will assign a default priority for IRQs.
 //
 #define AM_IRQ_PRIORITY_DEFAULT             4

--- a/mcu/apollo510/hal/mcu/am_hal_mcu_sysctrl.h
+++ b/mcu/apollo510/hal/mcu/am_hal_mcu_sysctrl.h
@@ -48,7 +48,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -77,7 +77,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #ifndef AM_HAL_MCU_SYSCTRL_H
@@ -195,7 +195,7 @@ extern void am_hal_sysctrl_fpu_stacking_disable(void);
 //
 //! @brief Issue a system wide reset using the AIRCR bit in the M4 system ctrl.
 //!
-//! This function issues a system wide reset (Apollo4P POR level reset).
+//! This function issues a system wide reset (Apollo510 POR level reset).
 //
 //*****************************************************************************
 extern void am_hal_sysctrl_aircr_reset(void);

--- a/mcu/apollo510/hal/mcu/am_hal_mcuctrl.c
+++ b/mcu/apollo510/hal/mcu/am_hal_mcuctrl.c
@@ -48,7 +48,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -77,7 +77,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -118,8 +118,10 @@ g_am_hal_mcuctrl_sku_mram_size[AM_HAL_MCUCTRL_SKU_MRAM_SIZE_N] =
 };
 
 // ****************************************************************************
+//
 // MCUCTRL XTALHSCAP Globals for Cooper Device
-// Refer to App Note Apollo4 Blue 32MHz Crystal Calibration
+// Refer to App Note "Apollo510 SoC External HFXTAL Crystal Calibration"
+//
 // ****************************************************************************
 uint32_t g_ui32xtalhscap2trim = XTALHSCAP2TRIM_DEFAULT;
 uint32_t g_ui32xtalhscaptrim = XTALHSCAPTRIM_DEFAULT;
@@ -665,22 +667,22 @@ am_hal_mcuctrl_status_get(am_hal_mcuctrl_status_t *psStatus)
 
 } // am_hal_mcuctrl_status_get()
 
-//*****************************************************************************
+// ****************************************************************************
 //
-//! @brief Get TRIM version from INFO1 register.
-//!
-//! @param psFeature - Pointer to feature structure to store trim version.
-//!
-//! @return Returns AM_HAL_STATUS_SUCCESS on success.
-//!
-//! This function reads the trim version information from the INFO1 register
-//! and decodes it according to the chip revision and PCM version.
-//!
-//*****************************************************************************
-static uint32_t
-trim_version_get(am_hal_mcuctrl_feature_t *psFeature)
+//  am_hal_mcuctrl_trim_version_get()
+//  Get TRIM version which is stored in INFO1.
+//
+// ****************************************************************************
+uint32_t
+am_hal_mcuctrl_trim_version_get(uint32_t *pui32TrimVersion)
 {
     uint32_t ui32Ret, ui32TrimVer;
+    am_hal_mcuctrl_trimver_t sTrimVersion;
+
+    if ( pui32TrimVersion == NULL )
+    {
+        return AM_HAL_STATUS_INVALID_ARG;
+    }
 
     //
     // Get trim information from the Apollo510 device.
@@ -692,7 +694,7 @@ trim_version_get(am_hal_mcuctrl_feature_t *psFeature)
                                 1,
                                 &ui32TrimVer);
 
-    psFeature->ui32trimver = 0x0;   // Initialize the trim data
+    sTrimVersion.ui32trimver = 0;
     if ( ui32Ret == AM_HAL_STATUS_SUCCESS )
     {
         if ( (MCUCTRL->CHIPREV_b.REVMAJ == MCUCTRL_CHIPREV_REVMAJ_B)    &&
@@ -711,32 +713,34 @@ trim_version_get(am_hal_mcuctrl_feature_t *psFeature)
                 //
                 --ui32TrimVer;
             }
-            psFeature->trimver_b.ui8TrimVerMaj = 2;
-            psFeature->trimver_b.ui8TrimVerMin = (uint8_t)ui32TrimVer;
-            psFeature->trimver_b.bTrimVerPCM   = 1;
-            psFeature->trimver_b.bTrimVerValid = 1;
+            sTrimVersion.trimver_b.ui8TrimVerMin = (uint8_t)ui32TrimVer;
+            sTrimVersion.trimver_b.ui8TrimVerMaj = 2;
+            sTrimVersion.trimver_b.bTrimVerValid = true;
+            sTrimVersion.trimver_b.bTrimVerPCM   = true;
         }
         else
         {
             //
             // Default to non-PCM numbered device.
             //
-            psFeature->trimver_b.ui8TrimVerMaj = 0;
-            psFeature->trimver_b.ui8TrimVerMin = (uint8_t)ui32TrimVer;
-            psFeature->trimver_b.bTrimVerPCM   = 0;
-            psFeature->trimver_b.bTrimVerValid = 1;
+            sTrimVersion.trimver_b.ui8TrimVerMin = (uint8_t)ui32TrimVer;
+            sTrimVersion.trimver_b.ui8TrimVerMaj = 0;
+            sTrimVersion.trimver_b.bTrimVerValid = false;
+            sTrimVersion.trimver_b.bTrimVerPCM   = true;
         }
     }
     else
     {
-        psFeature->trimver_b.ui8TrimVerMaj = 0;
-        psFeature->trimver_b.ui8TrimVerMin = (uint8_t)ui32TrimVer;
-        psFeature->trimver_b.bTrimVerPCM   = 0;
-        psFeature->trimver_b.bTrimVerValid = 0;
+        sTrimVersion.trimver_b.ui8TrimVerMin = (uint8_t)ui32TrimVer;
+        sTrimVersion.trimver_b.ui8TrimVerMaj = 0;
+        sTrimVersion.trimver_b.bTrimVerValid = false;
+        sTrimVersion.trimver_b.bTrimVerPCM   = false;
     }
 
+    *pui32TrimVersion = sTrimVersion.ui32trimver;
+
     return ui32Ret;
-} // trim_version_get()
+} // am_hal_mcuctrl_trim_version_get()
 
 // ****************************************************************************
 //
@@ -795,7 +799,7 @@ am_hal_mcuctrl_info_get(am_hal_mcuctrl_infoget_e eInfoGet, void *pInfo)
             psFeature->bFPU             = (MCUCTRL->SKU_b.SKUFPU > 0);
             psFeature->eMVECfg          = (am_hal_mcuctrl_mve_e)MCUCTRL->SKU_b.SKUMVE;
 
-            trim_version_get(psFeature);
+            am_hal_mcuctrl_trim_version_get(&psFeature->ui32trimver);
             break;
 
         case AM_HAL_MCUCTRL_INFO_DEVICEID:

--- a/mcu/apollo510/hal/mcu/am_hal_mcuctrl.h
+++ b/mcu/apollo510/hal/mcu/am_hal_mcuctrl.h
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #ifndef AM_HAL_MCUCTRL_H
@@ -55,10 +55,12 @@ extern "C"
 #define MCUCTRL_CHIPPN_PARTNUM_PN_M             0xFF000000
 #define MCUCTRL_CHIPPN_PARTNUM_PN_S             24
 
-//**********************************************************
-//! MCUCTRL XTALHSCAP defaults for Cooper
-//! Refer to App Note Apollo4 Blue 32MHz Crystal Calibration
-//**********************************************************
+// ****************************************************************************
+//
+//! MCUCTRL XTALHSCAP defaults for Apollo510
+//! Refer to App Note "Apollo510 SoC External HFXTAL Crystal Calibration"
+//
+// ****************************************************************************
 #define XTALHSCAP2TRIM_DEFAULT  44
 #define XTALHSCAPTRIM_DEFAULT   4
 
@@ -205,6 +207,15 @@ typedef enum
     AM_HAL_MCUCTRL_CONTROL_EXTCLK32M_CLKOUT_DISABLE
 } am_hal_mcuctrl_control_e;
 
+//
+// Macros for EXTCLK_HFXTAL naming convention (aliases for EXTCLK32M)
+//
+#define AM_HAL_MCUCTRL_CONTROL_EXTCLK_HFXTAL_KICK_START        AM_HAL_MCUCTRL_CONTROL_EXTCLK32M_KICK_START
+#define AM_HAL_MCUCTRL_CONTROL_EXTCLK_HFXTAL_NORMAL            AM_HAL_MCUCTRL_CONTROL_EXTCLK32M_NORMAL
+#define AM_HAL_MCUCTRL_CONTROL_EXTCLK_HFXTAL_DISABLE           AM_HAL_MCUCTRL_CONTROL_EXTCLK32M_DISABLE
+#define AM_HAL_MCUCTRL_CONTROL_EXTCLK_HFXTAL_CLKOUT_ENABLE     AM_HAL_MCUCTRL_CONTROL_EXTCLK32M_CLKOUT_ENABLE
+#define AM_HAL_MCUCTRL_CONTROL_EXTCLK_HFXTAL_CLKOUT_DISABLE    AM_HAL_MCUCTRL_CONTROL_EXTCLK32M_CLKOUT_DISABLE
+
 //**************************************
 //! MCUCTRL EXT32M status enumerations
 //**************************************
@@ -214,6 +225,13 @@ typedef enum
     AM_HAL_MCUCTRL_EXT32M_STATUS_XTAL,
     AM_HAL_MCUCTRL_EXT32M_STATUS_EXT_CLK,
 }am_hal_mcuctrl_ext32m_status_e;
+
+//
+// Macros for EXTCLK_HFXTAL status naming convention (aliases for EXT32M)
+//
+#define AM_HAL_MCUCTRL_EXTCLK_HFXTAL_STATUS_OFF                AM_HAL_MCUCTRL_EXT32M_STATUS_OFF
+#define AM_HAL_MCUCTRL_EXTCLK_HFXTAL_STATUS_XTAL               AM_HAL_MCUCTRL_EXT32M_STATUS_XTAL
+#define AM_HAL_MCUCTRL_EXTCLK_HFXTAL_STATUS_EXT_CLK            AM_HAL_MCUCTRL_EXT32M_STATUS_EXT_CLK
 
 //**************************************
 //! MCUCTRL EXT32K status enumerations
@@ -381,6 +399,27 @@ typedef struct
 
 //**************************************
 //
+//! MCUCTRL trimver structure
+//! Note, see also am_hal_mcuctrl_feature_t.
+//
+//**************************************
+typedef union                                           // Trim version info
+{
+    uint32_t ui32trimver;
+
+    struct
+    {
+        uint32_t ui8TrimVerMin  : 8;    // [7:0]
+        uint32_t ui8TrimVerMaj  : 8;    // [15:8]
+        uint32_t bTrimVerValid  : 1;    // [16:16] 1 if version data valid
+        uint32_t bTrimVerPCM    : 1;    // [17:17] 1 if PCM numbering
+        uint32_t bTrimVerRsvd18 : 6;    // [23:18]
+        uint32_t bTrimVerRsvd24 : 8;    // [31:24]
+    } trimver_b;
+} am_hal_mcuctrl_trimver_t;
+
+//**************************************
+//
 //! MCUCTRL features available structure
 //
 //**************************************
@@ -397,6 +436,11 @@ typedef struct
     bool                        bSecBootFeature;    // Secure Boot
     bool                        bFPU;               // FPU
     am_hal_mcuctrl_mve_e        eMVECfg;            // MVE
+    //
+    // Declare an anonymous union that is a copy of am_hal_mcuctrl_trimver_t.
+    // This is done so that the union members can be accessed directly as a
+    // member of am_hal_mcuctrl_feature_t.
+    //
     union                                           // Trim version info
     {
         uint32_t ui32trimver;
@@ -412,12 +456,12 @@ typedef struct
     };
 } am_hal_mcuctrl_feature_t;
 
-//**********************************************************
+// ****************************************************************************
 //
-//! MCUCTRL XTALHSCAP Globals for Cooper Device
-//! Refer to App Note Apollo4 Blue 32MHz Crystal Calibration
+//! MCUCTRL XTALHSCAP Globals for Apollo510 Device
+//! Refer to App Note "Apollo510 SoC External HFXTAL Crystal Calibration"
 //
-//**********************************************************
+// ****************************************************************************
 extern uint32_t g_ui32xtalhscap2trim;
 extern uint32_t g_ui32xtalhscaptrim;
 
@@ -484,6 +528,17 @@ extern uint32_t am_hal_mcuctrl_extclk32m_status_get(am_hal_mcuctrl_ext32m_status
 //
 // ****************************************************************************
 extern uint32_t am_hal_mcuctrl_status_get(am_hal_mcuctrl_status_t *psStatus);
+
+// ****************************************************************************
+//
+//! @brief Get trim version information.
+//!
+//! This function returns a data structure of trim revision information.
+//!
+//! @param psTrim - Pointer to the trim structure to receive the data.
+//
+// ****************************************************************************
+extern uint32_t am_hal_mcuctrl_trim_version_get(uint32_t *pui32trimver);
 
 // ****************************************************************************
 //

--- a/mcu/apollo510/hal/mcu/am_hal_mram.h
+++ b/mcu/apollo510/hal/mcu/am_hal_mram.h
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #ifndef AM_HAL_MRAM_H
@@ -249,8 +249,10 @@ extern uint32_t am_hal_mram_main_words_program(uint32_t ui32ProgramKey, uint32_t
 //
 //! @brief Initialize MRAM for DeepSleep.
 //!
-//! This function implements a workaround required for Apollo4 B0 parts in
-//! order to fix the MRAM DeepSleep config params.
+//! This function implements a workaround required for Apollo510 parts in
+//! order to fix the MRAM DeepSleep config params. The Apollo510 devices do not
+//! require this workaround, and thus this is only intended as a placeholder
+//! function.
 //!
 //! @return 0 for success, non-zero for failure.
 //

--- a/mcu/apollo510/hal/mcu/am_hal_mspi.h
+++ b/mcu/apollo510/hal/mcu/am_hal_mspi.h
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #ifndef AM_HAL_MSPI_H
@@ -770,7 +770,7 @@ typedef struct
     //! Enable Write Latency Counter
     bool                        bEnWRLatency;
 
-    //! Continuation (The MSPI CONT feature is deprecated for Apollo4.)
+    //! Continuation
     bool                        bContinue;
 
     //! Buffer

--- a/mcu/apollo510/hal/mcu/am_hal_puf.c
+++ b/mcu/apollo510/hal/mcu/am_hal_puf.c
@@ -53,14 +53,14 @@
 //! - No configuration is required for basic entropy or UID reads beyond
 //!   powering OTP.
 //! - Higher-level consumers may implement additional conditioning if required.
-//! - The Static UID provides 1024 bits (32 × 32-bit words) of device-unique
+//! - The Static UID provides 1024 bits (32 x 32-bit words) of device-unique
 //!   data suitable for fingerprinting and security applications.
 //
 //*****************************************************************************
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -89,7 +89,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision stable-c286075505 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -177,8 +177,8 @@ uint32_t
 am_hal_puf_get_entropy(uint8_t * buffer, uint16_t length)
 {
     //
-	// Validate input parameters.
-	//
+    // Validate input parameters.
+    //
     if (length == 0 || buffer == NULL)
     {
         return AM_HAL_STATUS_FAIL;
@@ -240,8 +240,8 @@ am_hal_puf_entropy_init(void)
     }
 
     //
-	// Record whether OTP was already enabled before we try to enable it.
-	//
+    // Record whether OTP was already enabled before we try to enable it.
+    //
     g_bPufOtpWasEnabled = bPeripheralEnabled;
 
     //
@@ -282,17 +282,17 @@ am_hal_puf_entropy_deinit(void)
     }
 
     //
-	// If OTP is already off, or OTP was already enabled before our init call,
-    // there is nothing for us to do here — return success.
-	//
+    // If OTP is already off, or OTP was already enabled before our init call,
+    // there is nothing for us to do here -- return success.
+    //
     if (!bPeripheralEnabled || g_bPufOtpWasEnabled)
     {
         return AM_HAL_STATUS_SUCCESS;
     }
 
     //
-	// Otherwise, OTP is on and we enabled it during init; disable it now.
-	//
+    // Otherwise, OTP is on and we enabled it during init; disable it now.
+    //
     ui32Status = am_hal_pwrctrl_periph_disable(AM_HAL_PWRCTRL_PERIPH_OTP);
     if (AM_HAL_STATUS_SUCCESS != ui32Status)
     {

--- a/mcu/apollo510/hal/mcu/am_hal_sdhc.h
+++ b/mcu/apollo510/hal/mcu/am_hal_sdhc.h
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #ifndef AM_HAL_SDHC_H
@@ -59,13 +59,6 @@ extern "C"
 //*****************************************************************************
 #define SDIO_Type                    SDIO0_Type
 #define SDHCn(n)                     ((SDIO_Type*)(SDIO0_BASE + (n * (SDIO1_BASE - SDIO0_BASE))))
-
-#define SDIO_INTSIG_CARDINTEN_Msk                       SDIO0_INTSIG_CARDINTEN_Msk
-#define SDIO_INTENABLE_CARDINTERRUPTSTATUSENABLE_Msk    SDIO0_INTENABLE_CARDINTERRUPTSTATUSENABLE_Msk
-#define SDIO_INTSIG_CARDINSERTEN_Msk                    SDIO0_INTSIG_CARDINSERTEN_Msk
-#define SDIO_INTENABLE_CARDINSERTIONSTATUSENABLE_Msk    SDIO0_INTENABLE_CARDINSERTIONSTATUSENABLE_Msk
-#define SDIO_INTSIG_CARDREMOVALEN_Msk                   SDIO0_INTSIG_CARDREMOVALEN_Msk
-#define SDIO_INTENABLE_CARDREMOVALSTATUSENABLE_Msk      SDIO0_INTENABLE_CARDREMOVALSTATUSENABLE_Msk
 
 //
 //! SD Host software reset types

--- a/mcu/apollo510/hal/mcu/am_hal_secure_ota.c
+++ b/mcu/apollo510/hal/mcu/am_hal_secure_ota.c
@@ -47,7 +47,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -76,7 +76,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #include <stdint.h>
@@ -137,7 +137,6 @@ am_hal_ota_init(uint32_t ui32ProgramKey, am_hal_otadesc_t *pOtaDesc)
     return status;
 }
 
-// Add a new OTA to descriptor
 //*****************************************************************************
 //
 // Adds a new image to the OTA Descriptor.

--- a/mcu/apollo510/hal/mcu/am_hal_secure_ota.h
+++ b/mcu/apollo510/hal/mcu/am_hal_secure_ota.h
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -54,12 +54,12 @@
 //
 #define AM_IMAGE_MAGIC_SBL                0xA3
 #define AM_IMAGE_MAGIC_SECURE             0xC0
-#define AM_IMAGE_MAGIC_OEM_CHAIN          0xCC
-#define AM_IMAGE_MAGIC_NONSECURE          0xCB
-#define AM_IMAGE_MAGIC_INFO0              0xCF
 #define AM_IMAGE_MAGIC_CONTAINER          0xC1
-#define AM_IMAGE_MAGIC_KEYREVOKE          0xCE
+#define AM_IMAGE_MAGIC_NONSECURE          0xCB
+#define AM_IMAGE_MAGIC_OEM_CHAIN          0xCC
 #define AM_IMAGE_MAGIC_DOWNLOAD           0xCD
+#define AM_IMAGE_MAGIC_KEYREVOKE          0xCE
+#define AM_IMAGE_MAGIC_INFO0              0xCF
 //! @}
 
 //
@@ -74,6 +74,7 @@ typedef enum
     AM_PROG_INFO0_MRAM, //program info0 mram
     AM_PROG_INFO0_BOTH // program both info0 opt and info0 mram
 } am_info0_prog_dest_e;
+
 //
 //! OTA Image HDR Info
 //

--- a/mcu/apollo510/hal/mcu/am_hal_sysctrl.c
+++ b/mcu/apollo510/hal/mcu/am_hal_sysctrl.c
@@ -47,7 +47,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -76,7 +76,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -837,7 +837,7 @@ am_hal_sysctrl_clkmuxrst_low_power_init()
 
             // If XTAL is marked needed, kick start XTAL
             if (HALSTATE_b.XTAL_NEEDED ||
-                (HALSTATE_b.PLL_NEEDED && HALSTATE_b.PLL_FREFSEL == MCUCTRL_PLLCTL0_FREFSEL_XTAL32MHz))
+                (HALSTATE_b.PLL_NEEDED && HALSTATE_b.PLL_FREFSEL == MCUCTRL_PLLCTL0_FREFSEL_XTAL_HS))
             {
                 bool bFalse = false;
                 am_hal_mcuctrl_control(AM_HAL_MCUCTRL_CONTROL_EXTCLK32M_KICK_START, &bFalse);
@@ -936,7 +936,7 @@ am_hal_sysctrl_clkmuxrst_low_power_init()
             {
                 SYSPLLn(0)->PLLCTL0_b.SYSPLLPDB      = MCUCTRL_PLLCTL0_SYSPLLPDB_DISABLE;
                 SYSPLLn(0)->PLLCTL0_b.BYPASS         = 0;
-                SYSPLLn(0)->PLLCTL0_b.FREFSEL        = MCUCTRL_PLLCTL0_FREFSEL_XTAL32MHz;
+                SYSPLLn(0)->PLLCTL0_b.FREFSEL        = MCUCTRL_PLLCTL0_FREFSEL_XTAL_HS;
                 SYSPLLn(0)->PLLCTL0_b.FOUT4PHASEPD   = MCUCTRL_PLLCTL0_FOUT4PHASEPD_POWERDOWN;
                 SYSPLLn(0)->PLLCTL0_b.FOUTPOSTDIVPD  = MCUCTRL_PLLCTL0_FOUTPOSTDIVPD_POWERDOWN;
                 am_hal_pwrctrl_syspll_disable();
@@ -958,7 +958,7 @@ am_hal_sysctrl_clkmuxrst_low_power_init()
 
             // If XTAL was started, power XTAL off
             if (HALSTATE_b.XTAL_NEEDED ||
-                (HALSTATE_b.PLL_NEEDED && HALSTATE_b.PLL_FREFSEL == MCUCTRL_PLLCTL0_FREFSEL_XTAL32MHz))
+                (HALSTATE_b.PLL_NEEDED && HALSTATE_b.PLL_FREFSEL == MCUCTRL_PLLCTL0_FREFSEL_XTAL_HS))
             {
                 bool bFalse = false;
                 am_hal_mcuctrl_control(AM_HAL_MCUCTRL_CONTROL_EXTCLK32M_DISABLE, &bFalse);

--- a/mcu/apollo510/hal/mcu/am_hal_syspll.h
+++ b/mcu/apollo510/hal/mcu/am_hal_syspll.h
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #ifndef AM_HAL_SYSPLL_H
@@ -65,7 +65,7 @@ extern "C"
 //
 //*****************************************************************************
 #define AM_HAL_SYSPLL_MAX_REFDIV                (63U)
-#define AM_HAL_SYSPLL_MIN_FBDIV_INT_MODE        (4U)
+#define AM_HAL_SYSPLL_MIN_FBDIV_INT_MODE        (10U)
 #define AM_HAL_SYSPLL_MAX_FBDIV_INT_MODE        (960U)
 #define AM_HAL_SYSPLL_MIN_FBDIV_FRAC_MODE       (10U)
 #define AM_HAL_SYSPLL_MAX_FBDIV_FRAC_MODE       (96U)
@@ -118,7 +118,7 @@ typedef enum
 // ****************************************************************************
 typedef enum
 {
-    AM_HAL_SYSPLL_FREFSEL_XTAL32MHz = MCUCTRL_PLLCTL0_FREFSEL_XTAL32MHz,
+    AM_HAL_SYSPLL_FREFSEL_XTAL32MHz = MCUCTRL_PLLCTL0_FREFSEL_XTAL_HS,
     AM_HAL_SYSPLL_FREFSEL_EXTREFCLK = MCUCTRL_PLLCTL0_FREFSEL_EXTREFCLK,
 } am_hal_syspll_frefsel_e;
 

--- a/mcu/apollo510/hal/mcu/am_hal_uart.c
+++ b/mcu/apollo510/hal/mcu/am_hal_uart.c
@@ -48,7 +48,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -77,7 +77,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -170,7 +170,7 @@ typedef struct
     //! Pointer to the dma buffer descriptor queue
     //! This is allocated by the calling function in application space
     //! and is attached to this struct via a call to
-    //! am_hal_uart_dmaQueueInit
+    //! am_hal_uart_stream_dmaQueueInit
     //! @note Since it is allocated and passed in, this usually shouldn't be on the stack
     //
     am_hal_uart_dma_config_t *psDmaQueue;
@@ -643,7 +643,6 @@ am_hal_uart_dma_transfer_complete(void *pHandle)
     //
     UARTn(ui32Module)->RSR_b.DMACPL = 0x0;
     UARTn(ui32Module)->RSR_b.DMAERR = 0x0;
-    pState->bDMABusy = false;
 }
 
 //*****************************************************************************
@@ -821,7 +820,6 @@ am_hal_uart_dma_abort(void *pHandle)
     // DMA count cleared.
     //
     UARTn(ui32Module)->COUNT_b.TOTCOUNT = 0x0;
-    pState->bDMABusy = false;
 }
 
 //*****************************************************************************
@@ -944,7 +942,11 @@ config_baudrate(uint32_t ui32Module, uint32_t ui32DesiredBaudrate, uint32_t *pui
     switch ( UARTn(ui32Module)->CR_b.CLKSEL )
     {
         case UART0_CR_CLKSEL_PLL_CLK:
-            ui32UartClkFreq = 49152000;
+            am_hal_clkmgr_clock_config_get(AM_HAL_CLKMGR_CLK_ID_SYSPLL, &ui32UartClkFreq, NULL);
+            if ( ui32UartClkFreq == 0 )
+            {
+                return AM_HAL_UART_STATUS_CLOCK_NOT_CONFIGURED;
+            }
             break;
 
         case UART0_CR_CLKSEL_HFRC_48MHZ:
@@ -2380,6 +2382,7 @@ am_hal_uart_interrupt_service(void *pHandle, uint32_t ui32Status)
             //
             am_hal_uart_dma_transfer_complete(pHandle);
         }
+        pState->bDMABusy = false;
     }
     else
     {

--- a/mcu/apollo510/hal/mcu/am_hal_uart.h
+++ b/mcu/apollo510/hal/mcu/am_hal_uart.h
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -700,19 +700,6 @@ extern void am_hal_uart_dma_abort(void *pHandle);
 //
 //*****************************************************************************
 extern uint32_t am_hal_uart_dma_transfer(void *pHandle, am_hal_uart_transfer_t *psTransaction);
-
-//*****************************************************************************
-//
-//! @brief UART DMA transaction completes, clear config and status
-//!
-//! @param pHandle is the UART handle to use.
-//!
-//! This function disables and clears UART DMA.
-//!
-//! @return void.
-//
-//*****************************************************************************
-extern void am_hal_uart_dma_transfer_complete(void *pHandle);
 
 //*****************************************************************************
 //

--- a/mcu/apollo510/hal/mcu/am_hal_uart_stream.c
+++ b/mcu/apollo510/hal/mcu/am_hal_uart_stream.c
@@ -48,7 +48,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -77,7 +77,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_5p1p0beta-2927d425bf of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -1047,7 +1047,7 @@ am_hal_uart_interrupt_stream_service(void *pUartHandle)
         psState->bBusyWaitEnabled = false;
         while (pUart->FR & UART0_FR_BUSY_Msk)
         {
-            // @todo do we need a timeout here
+            // TODO FIXME do we need a timeout here
         }
         ui32RetStat |= AM_HAL_UART_STREAM_STATUS_BUSY_WAIT_CMPL;
 
@@ -2436,7 +2436,14 @@ config_baudrate(uint32_t ui32Module,
     switch ( UARTn(ui32Module)->CR_b.CLKSEL )
     {
         case UART0_CR_CLKSEL_PLL_CLK:
-            ui32UartClkFreq = 49152000;
+            //
+            // Get the current SYSPLL frequency from clock manager
+            //
+            am_hal_clkmgr_clock_config_get(AM_HAL_CLKMGR_CLK_ID_SYSPLL, &ui32UartClkFreq, NULL);
+            if ( ui32UartClkFreq == 0 )
+            {
+                return AM_HAL_UART_STATUS_CLOCK_NOT_CONFIGURED;
+            }
             break;
 
         case UART0_CR_CLKSEL_HFRC_48MHZ:

--- a/mcu/apollo510/hal/mcu/am_hal_uart_stream.h
+++ b/mcu/apollo510/hal/mcu/am_hal_uart_stream.h
@@ -12,7 +12,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -41,7 +41,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_5p1p0beta-2927d425bf of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #ifndef AM_HAL_UART_STREAM_H
@@ -65,6 +65,10 @@ extern "C"
 
 #define AM_HAL_UART_FIFO_MAX 32
 
+//
+//! Clock frequency when using SYSPLL as clock source
+//
+#define AM_HAL_UART_STREAM_PLLCLK_FREQ             49152000
 
 //
 //! Contains computed values from uart config.
@@ -344,7 +348,7 @@ typedef struct
 
     uint8_t     align[2];
 }
-am_hal_uart_stream_rx_params_t;  // @todo change name
+am_hal_uart_stream_rx_params_t;  // TODO FIXME change name
 
 //
 //! enum specifying active dma mode

--- a/utils/am_util.h
+++ b/utils/am_util.h
@@ -14,7 +14,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -43,7 +43,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #ifndef AM_UTIL_H
@@ -68,6 +68,7 @@
 #include "am_util_stdio.h"
 #include "am_util_string.h"
 #include "am_util_time.h"
+#include "am_util_bootloader.h"
 
 #if defined(AM_PART_APOLLO3_API)
 #include "am_util_ble.h"

--- a/utils/am_util_delay.c
+++ b/utils/am_util_delay.c
@@ -53,7 +53,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -82,7 +82,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -102,11 +102,11 @@ am_util_delay_cycles(uint32_t ui32Iterations)
     //
     // Call the BOOTROM cycle delay function
     //
-#if defined(AM_PART_APOLLO4_API) || defined(AM_PART_APOLLO5_API)
-    am_hal_delay_us( ui32Iterations);
-#else
+#if defined(AM_PART_APOLLO) || defined(AM_PART_APOLLO2) || defined(AM_PART_APOLLO3) || defined(AM_PART_APOLLO3P)
     am_hal_flash_delay(ui32Iterations);
-#endif // AM_PART_APOLLO4_API || AM_PART_APOLLO5_API
+#else
+    am_hal_delay_us( ui32Iterations);
+#endif
 }
 
 //*****************************************************************************
@@ -117,9 +117,7 @@ am_util_delay_cycles(uint32_t ui32Iterations)
 void
 am_util_delay_ms(uint32_t ui32MilliSeconds)
 {
-#if defined(AM_PART_APOLLO4_API) || defined(AM_PART_APOLLO5_API)
-    am_hal_delay_us( ui32MilliSeconds * 1000);
-#else // AM_PART_APOLLO4_API || AM_PART_APOLLO5_API
+#if defined(AM_PART_APOLLO) || defined(AM_PART_APOLLO2) || defined(AM_PART_APOLLO3) || defined(AM_PART_APOLLO3P)
     uint32_t ui32Loops, ui32HFRC;
 #if AM_APOLLO3_CLKGEN
     am_hal_clkgen_status_t sClkgenStatus;
@@ -134,7 +132,9 @@ am_util_delay_ms(uint32_t ui32MilliSeconds)
     // Call the BOOTROM cycle delay function
     //
     am_hal_flash_delay(ui32Loops);
-#endif // AM_PART_APOLLO4_API || AM_PART_APOLLO5_API
+#else
+    am_hal_delay_us( ui32MilliSeconds * 1000);
+#endif
 }
 
 //*****************************************************************************
@@ -145,9 +145,7 @@ am_util_delay_ms(uint32_t ui32MilliSeconds)
 void
 am_util_delay_us(uint32_t ui32MicroSeconds)
 {
-#if defined(AM_PART_APOLLO4_API) || defined(AM_PART_APOLLO5_API)
-    am_hal_delay_us( ui32MicroSeconds );
-#else // AM_PART_APOLLO4_API || AM_PART_APOLLO5_API
+#if defined(AM_PART_APOLLO) || defined(AM_PART_APOLLO2) || defined(AM_PART_APOLLO3) || defined(AM_PART_APOLLO3P)
     uint32_t ui32Loops, ui32HFRC;
 
 #if AM_APOLLO3_CLKGEN
@@ -163,7 +161,9 @@ am_util_delay_us(uint32_t ui32MicroSeconds)
     // Call the BOOTROM cycle delay function
     //
     am_hal_flash_delay(ui32Loops);
-#endif // AM_PART_APOLLO4_API || AM_PART_APOLLO5_API
+#else
+    am_hal_delay_us( ui32MicroSeconds );
+#endif
 }
 
 //*****************************************************************************

--- a/utils/am_util_stdio.c
+++ b/utils/am_util_stdio.c
@@ -55,7 +55,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -84,7 +84,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 
@@ -101,10 +101,11 @@
 
 // function pointer for printf
 am_util_stdio_print_char_t g_pfnCharPrint;
+am_util_stdio_get_char_t g_pfnCharGet;
 
 // buffer for printf
 #ifdef AM_PART_APOLLO5_API
-static char g_prfbuf[AM_PRINTF_BUFSIZE] __attribute__((aligned(4096)));
+static char g_prfbuf[AM_PRINTF_BUFSIZE * 2] __attribute__((aligned(4096)));
 #else
 static char g_prfbuf[AM_PRINTF_BUFSIZE];
 #endif
@@ -121,6 +122,12 @@ void
 am_util_stdio_printf_init(am_util_stdio_print_char_t pfnCharPrint)
 {
     g_pfnCharPrint = pfnCharPrint;
+}
+
+void
+am_util_stdio_scanf_init(am_util_stdio_get_char_t pfnCharGet)
+{
+    g_pfnCharGet = pfnCharGet;
 }
 
 //*****************************************************************************
@@ -1291,10 +1298,202 @@ am_util_stdio_terminal_clear(void)
     am_util_stdio_printf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
 }
 
+static uint64_t hexstr_to_uint64(const char *str, uint32_t *count)
+{
+    uint64_t val = 0;
+    uint32_t c = 0;
+    while ((*str >= '0' && *str <= '9') || (*str >= 'a' && *str <= 'f') || (*str >= 'A' && *str <= 'F'))
+    {
+        val <<= 4;
+        if ( *str >= '0' && *str <= '9' )
+        {
+            val += *str - '0';
+        }
+        else if ( *str >= 'a' && *str <= 'f' )
+        {
+            val += (*str - 'a') + 10;
+        }
+        else
+        {
+            val += (*str - 'A') + 10;
+        }
+        str++;
+        c++;
+    }
+    if (count)
+    {
+        *count = c;
+    }
+    return val;
+}
+
+static float str_to_float(const char *str, uint32_t *count)
+{
+    float result = 0.0f;
+    float sign = 1.0f;
+    float frac = 0.1f;
+    uint32_t c = 0;
+
+    if (*str == '-')
+    {
+        sign = -1.0f;
+        str++;
+        c++;
+    }
+    while (*str >= '0' && *str <= '9')
+    {
+        result = result * 10.0f + (*str - '0');
+        str++;
+        c++;
+    }
+    if (*str == '.')
+    {
+        str++;
+        c++;
+        while (*str >= '0' && *str <= '9')
+        {
+            result += (*str - '0') * frac;
+            frac *= 0.1f;
+            str++;
+            c++;
+        }
+    }
+    if (count)
+    {
+        *count = c;
+    }
+    return result * sign;
+}
+
+uint32_t am_util_stdio_vsscanf(const char *input, const char *fmt, va_list args)
+{
+    uint32_t num_assigned = 0;
+
+    while (*fmt && *input)
+    {
+        if (*fmt == '%')
+        {
+            ++fmt;
+            bool longlong = false;
+            if (*fmt == 'l')
+            {
+                ++fmt;
+                if (*fmt == 'l')
+                {
+                    longlong = true;
+                    ++fmt;
+                }
+            }
+
+            uint32_t count = 0;
+            switch (*fmt)
+            {
+                case 'd': case 'i':
+                    if (longlong)
+                    {
+                        int64_t *p = va_arg(args, int64_t*);
+                        *p = (int64_t)decstr_to_int(input, &count);
+                    }
+                    else
+                    {
+                        int *p = va_arg(args, int*);
+                        *p = (int)decstr_to_int(input, &count);
+                    }
+                    input += count;
+                    num_assigned++;
+                    break;
+                case 'u':
+                    if (longlong)
+                    {
+                        uint64_t *p = va_arg(args, uint64_t*);
+                        *p = (uint64_t)decstr_to_int(input, &count);
+                    }
+                    else
+                    {
+                        unsigned *p = va_arg(args, unsigned*);
+                        *p = (unsigned)decstr_to_int(input, &count);
+                    }
+                    input += count;
+                    num_assigned++;
+                    break;
+                case 'x': case 'X':
+                    if (longlong)
+                    {
+                        uint64_t *p = va_arg(args, uint64_t*);
+                        *p = hexstr_to_uint64(input, &count);
+                    }
+                    else
+                    {
+                        unsigned *p = va_arg(args, unsigned*);
+                        *p = (unsigned)hexstr_to_uint64(input, &count);
+                    }
+                    input += count;
+                    num_assigned++;
+                    break;
+                case 'f':
+                {
+                    float *p = va_arg(args, float*);
+                    *p = str_to_float(input, &count);
+                    input += count;
+                    num_assigned++;
+                    break;
+                }
+                case 's':
+                {
+                    char *p = va_arg(args, char*);
+                    while (*input && *input != ' ' && *input != '\n')
+                    {
+                        *p++ = *input++;
+                        count++;
+                    }
+                    *p = '\0';
+                    num_assigned++;
+                    break;
+                }
+                case 'c':
+                {
+                    char *p = va_arg(args, char*);
+                    *p = *input++;
+                    num_assigned++;
+                    break;
+                }
+                default:
+                    return num_assigned;
+            }
+            ++fmt;
+        }
+        else if (*fmt == *input)
+        {
+            ++fmt;
+            ++input;
+        }
+        else
+        {
+            break;
+        }
+    }
+    return num_assigned;
+}
+
+uint32_t am_util_stdio_scanf(const char *fmt, ...)
+{
+    if (!g_pfnCharGet)
+    {
+        return 0;
+    }
+
+    g_pfnCharGet(g_prfbuf + AM_PRINTF_BUFSIZE);
+
+    va_list args;
+    va_start(args, fmt);
+    uint32_t ret = am_util_stdio_vsscanf((const char *)(g_prfbuf + AM_PRINTF_BUFSIZE), fmt, args);
+    va_end(args);
+    return ret;
+}
+
 //*****************************************************************************
 //
 // End Doxygen group.
 //! @}
 //
 //*****************************************************************************
-

--- a/utils/am_util_stdio.h
+++ b/utils/am_util_stdio.h
@@ -14,7 +14,7 @@
 
 //*****************************************************************************
 //
-// Copyright (c) 2025, Ambiq Micro, Inc.
+// Copyright (c) 2026, Ambiq Micro, Inc.
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
@@ -43,7 +43,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 //
-// This is part of revision release_sdk5p1p0-366b80e084 of the AmbiqSuite Development Package.
+// This is part of revision release_sdk5p2p0-440cb810d of the AmbiqSuite Development Package.
 //
 //*****************************************************************************
 #ifndef AM_UTIL_STDIO_H
@@ -69,6 +69,7 @@ extern "C"
 #endif
 
 typedef void (*am_util_stdio_print_char_t)(char *pcStr);
+typedef void (*am_util_stdio_get_char_t)(char *pcStr);
 
 //*****************************************************************************
 //
@@ -87,6 +88,19 @@ typedef void (*am_util_stdio_print_char_t)(char *pcStr);
 //
 //*****************************************************************************
 extern void am_util_stdio_printf_init(am_util_stdio_print_char_t pfnCharPrint);
+
+//*****************************************************************************
+//
+//! @brief Sets the interface for scanf calls.
+//!
+//! @param pfnCharGet - Function pointer to be used to get from interface
+//!
+//! This function initializes the global scanf function which is used for
+//! scanf. This allows users to define their own scanf interface and pass it
+//! in as a am_util_stdio_get_char_t type.
+//
+//*****************************************************************************
+extern void am_util_stdio_scanf_init(am_util_stdio_get_char_t pfnCharGet);
 
 //*****************************************************************************
 //
@@ -182,6 +196,17 @@ extern uint32_t am_util_stdio_sprintf(char *pcBuf, const char *pcFmt, ...);
 //
 // *****************************************************************************
 extern uint32_t am_util_stdio_printf(const char *pcFmt, ...);
+
+//*****************************************************************************
+//
+//! @brief A lite version of scanf()
+//!
+//! @param *fmt - Pointer to formatter string
+//!
+//! @return uint32_t representing the number of characters scanned.
+//
+// *****************************************************************************
+extern uint32_t am_util_stdio_scanf(const char *fmt, ...);
 
 //******************************************************************************
 //
@@ -279,4 +304,3 @@ extern void am_util_stdio_terminal_clear(void);
 //! @}
 //
 //*****************************************************************************
-


### PR DESCRIPTION
sdk5.2.0 updates
ADC: change VREF from 1.19V to 1.20V for Apollo510 ADC: add calibration with fKONST factor and overflow/underflow protection ADC: update temperature sensor slope to 302.11
DSI: add am_hal_dsi_config() API supporting video and command modes DSI: add RGB565/666/888 pixel format support
DSI: add video mode timing parameter configuration USB: add automatic PHY clock configuration for 12MHz and 24MHz USB: fix DMA transfer completion and ZLP handling
USB: simplify device speed query to use cached state STIMER: fix compare delta timing for 3-cycle write latency STIMER: update sentinel values to avoid stale interrupts UART: use clock manager API to query SYSPLL frequency UART: fix DMA busy flag handling in interrupt service MCUCTRL: add am_hal_mcuctrl_trim_version_get() API MCUCTRL: add HFXTAL aliases for EXTCLK32M macros
SYSPLL: update minimum FBDIV for integer mode from 4 to 10 Power: use power control API for crypto powerdown
SpotMgr: add compiler guards to avoid unsigned comparison warnings Utils: add scanf support with am_util_stdio_scanf() Utils: update delay functions to use platform-appropriate APIs